### PR TITLE
docs: add warning for API authentication failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ cd remnawave-STEALTHNET-Bot
 bash install.sh
 ```
 
+> [!WARNING]
+> Если после запуска у вас **падает API** сервис, бот отвечает «**❌ fetch failed**», а в логах «docker compose logs -f api» видим ошибку «**Error: P1000: Authentication failed**», значит нужно пересобрать контейнеры командой:
+> 
+> docker compose build api bot
+
 > **Если при запуске появляется ошибка** вида `invalid option nameet: pipefail` — у скрипта могли сохраниться переводы строк в формате Windows (CRLF). Исправление: `sed -i 's/\r$//' install.sh`, затем снова `bash install.sh`.
 
 Интерактивный установщик за 2 минуты настроит всё:


### PR DESCRIPTION
- Added a warning block for API service crashes after initial setup
- Explained the "❌ fetch failed" error and "P1000: Authentication failed" log message
- Provided the command `docker compose build api bot` to resolve the issue