### PR TITLE
Update date formatting in BackupPage

### DIFF
--- a/frontend/src/pages/backup.tsx
+++ b/frontend/src/pages/backup.tsx
@@ -22,8 +22,11 @@ function formatSize(bytes: number): string {
 }
 
 function formatDate(path: string): string {
-  const parts = path.split("/");
-  if (parts.length >= 3) return parts.slice(0, 3).join(".");
+  const parts = path.split(".");
+  if (parts.length === 3) {
+    const [year, month, day] = parts;
+    return `${day}.${month}.${year}`;
+  }
   return path;
 }
 


### PR DESCRIPTION
Change date formatting to use '.' as separator and expect three parts.