### PR TITLE
fix(frontend): remove redundant payment method icons

### DIFF
--- a/frontend/src/pages/cabinet/client-custom-build.tsx
+++ b/frontend/src/pages/cabinet/client-custom-build.tsx
@@ -490,7 +490,7 @@ export function ClientCustomBuildPage() {
                             <div className={cn("absolute left-6 p-1.5 rounded-lg transition-colors", c.bg10, c.bg20)}>
                               {payLoading ? <Loader2 className={cn("h-5 w-5 animate-spin", c.text)} /> : p.icon === "crypto" ? <Zap className={cn("h-5 w-5", c.text)} /> : <CreditCard className={cn("h-5 w-5", c.text)} />}
                             </div>
-                            <span className="text-base font-medium">{p.icon === "crypto" ? "⚡" : "💳"} {p.label}</span>
+                            <span className="text-base font-medium">{p.label}</span>
                           </>
                         )}
                       </Button>
@@ -510,7 +510,7 @@ export function ClientCustomBuildPage() {
                             <div className="absolute left-6 p-1.5 rounded-lg bg-green-500/10 group-hover:bg-green-500/20 transition-colors">
                               {payLoading ? <Loader2 className="h-5 w-5 animate-spin text-green-500" /> : <CreditCard className="h-5 w-5 text-green-500" />}
                             </div>
-                            <span className="text-base font-medium">💳 {m.label}</span>
+                            <span className="text-base font-medium">{m.label}</span>
                           </>
                         )}
                       </Button>

--- a/frontend/src/pages/cabinet/client-extra-options.tsx
+++ b/frontend/src/pages/cabinet/client-extra-options.tsx
@@ -464,7 +464,7 @@ export function ClientExtraOptionsPage() {
                           <div className={cn("absolute left-6 p-1.5 rounded-lg transition-colors", c.bg10, c.bg20)}>
                             {payLoading ? <Loader2 className={cn("h-5 w-5 animate-spin", c.text)} /> : p.icon === "crypto" ? <Zap className={cn("h-5 w-5", c.text)} /> : <CreditCard className={cn("h-5 w-5", c.text)} />}
                           </div>
-                          <span className="text-base font-medium">{p.icon === "crypto" ? "⚡" : "💳"} {p.label}</span>
+                          <span className="text-base font-medium">{p.label}</span>
                         </>
                       )}
                     </Button>
@@ -484,7 +484,7 @@ export function ClientExtraOptionsPage() {
                           <div className="absolute left-6 p-1.5 rounded-lg bg-green-500/10 group-hover:bg-green-500/20 transition-colors">
                             {payLoading ? <Loader2 className="h-5 w-5 animate-spin text-green-500" /> : <CreditCard className="h-5 w-5 text-green-500" />}
                           </div>
-                          <span className="text-base font-medium">💳 {m.label}</span>
+                          <span className="text-base font-medium">{m.label}</span>
                         </>
                       )}
                     </Button>

--- a/frontend/src/pages/cabinet/client-profile.tsx
+++ b/frontend/src/pages/cabinet/client-profile.tsx
@@ -1270,7 +1270,7 @@ function ClassicProfilePage() {
                           <div className={cn("absolute left-6 p-1.5 rounded-lg transition-colors", c.bg10, c.bg20)}>
                             {topUpLoading ? <Loader2 className={cn("h-5 w-5 animate-spin", c.text)} /> : p.icon === "crypto" ? <Zap className={cn("h-5 w-5", c.text)} /> : <CreditCard className={cn("h-5 w-5", c.text)} />}
                           </div>
-                          <span className="text-base font-medium">{p.icon === "crypto" ? "⚡" : "💳"} {p.label}</span>
+                          <span className="text-base font-medium">{p.label}</span>
                         </>
                       )}
                     </Button>
@@ -1290,7 +1290,7 @@ function ClassicProfilePage() {
                           <div className="absolute left-6 p-1.5 rounded-lg bg-green-500/10 group-hover:bg-green-500/20 transition-colors">
                             {topUpLoading ? <Loader2 className="h-5 w-5 animate-spin text-green-500" /> : <CreditCard className="h-5 w-5 text-green-500" />}
                           </div>
-                          <span className="text-base font-medium">💳 {m.label}</span>
+                          <span className="text-base font-medium">{m.label}</span>
                         </>
                       )}
                     </Button>

--- a/frontend/src/pages/cabinet/client-proxy.tsx
+++ b/frontend/src/pages/cabinet/client-proxy.tsx
@@ -434,7 +434,7 @@ export function ClientProxyPage() {
                           <div className={cn("absolute left-6 p-1.5 rounded-lg transition-colors", c.bg10, c.bg20)}>
                             {payLoading ? <Loader2 className={cn("h-5 w-5 animate-spin", c.text)} /> : p.icon === "crypto" ? <Zap className={cn("h-5 w-5", c.text)} /> : <CreditCard className={cn("h-5 w-5", c.text)} />}
                           </div>
-                          <span className="text-base font-medium">{p.icon === "crypto" ? "⚡" : "💳"} {p.label}</span>
+                          <span className="text-base font-medium">{p.label}</span>
                         </>
                       )}
                     </Button>
@@ -454,7 +454,7 @@ export function ClientProxyPage() {
                           <div className="absolute left-6 p-1.5 rounded-lg bg-green-500/10 group-hover:bg-green-500/20 transition-colors">
                             {payLoading ? <Loader2 className="h-5 w-5 animate-spin text-green-500" /> : <CreditCard className="h-5 w-5 text-green-500" />}
                           </div>
-                          <span className="text-base font-medium">💳 {m.label}</span>
+                          <span className="text-base font-medium">{m.label}</span>
                         </>
                       )}
                     </Button>

--- a/frontend/src/pages/cabinet/client-singbox.tsx
+++ b/frontend/src/pages/cabinet/client-singbox.tsx
@@ -430,7 +430,7 @@ export function ClientSingboxPage() {
                           <div className={cn("absolute left-6 p-1.5 rounded-lg transition-colors", c.bg10, c.bg20)}>
                             {payLoading ? <Loader2 className={cn("h-5 w-5 animate-spin", c.text)} /> : p.icon === "crypto" ? <Zap className={cn("h-5 w-5", c.text)} /> : <CreditCard className={cn("h-5 w-5", c.text)} />}
                           </div>
-                          <span className="text-base font-medium">{p.icon === "crypto" ? "⚡" : "💳"} {p.label}</span>
+                          <span className="text-base font-medium">{p.label}</span>
                         </>
                       )}
                     </Button>
@@ -450,7 +450,7 @@ export function ClientSingboxPage() {
                           <div className="absolute left-6 p-1.5 rounded-lg bg-green-500/10 group-hover:bg-green-500/20 transition-colors">
                             {payLoading ? <Loader2 className="h-5 w-5 animate-spin text-green-500" /> : <CreditCard className="h-5 w-5 text-green-500" />}
                           </div>
-                          <span className="text-base font-medium">💳 {m.label}</span>
+                          <span className="text-base font-medium">{m.label}</span>
                         </>
                       )}
                     </Button>

--- a/frontend/src/pages/cabinet/client-tariffs.tsx
+++ b/frontend/src/pages/cabinet/client-tariffs.tsx
@@ -1185,7 +1185,7 @@ function ClassicTariffsPage() {
                           <div className={cn("absolute left-6 p-1.5 rounded-lg transition-colors", c.bg10, c.bg20)}>
                             {payLoading ? <Loader2 className={cn("h-5 w-5 animate-spin", c.text)} /> : p.icon === "crypto" ? <Zap className={cn("h-5 w-5", c.text)} /> : <CreditCard className={cn("h-5 w-5", c.text)} />}
                           </div>
-                          <span className="text-base font-medium">{p.icon === "crypto" ? "⚡" : "💳"} {p.label}</span>
+                          <span className="text-base font-medium">{p.label}</span>
                         </>
                       )}
                     </Button>
@@ -1205,7 +1205,7 @@ function ClassicTariffsPage() {
                           <div className="absolute left-6 p-1.5 rounded-lg bg-green-500/10 group-hover:bg-green-500/20 transition-colors">
                             {payLoading ? <Loader2 className="h-5 w-5 animate-spin text-green-500" /> : <CreditCard className="h-5 w-5 text-green-500" />}
                           </div>
-                          <span className="text-base font-medium">💳 {m.label}</span>
+                          <span className="text-base font-medium">{m.label}</span>
                         </>
                       )}
                     </Button>


### PR DESCRIPTION
- Removed "⚡" and "💳" icons from payment method labels.
- Simplifies the UI by displaying only the payment method label.

#82