### PR TITLE
fix(analytics): дырка в ряду данных роняла страницу аналитики

### DIFF
--- a/frontend/src/pages/analytics.tsx
+++ b/frontend/src/pages/analytics.tsx
@@ -693,7 +693,10 @@ function aggregateByWeek(series: { date: string; value: number }[]): { label: st
   for (let i = 0; i < series.length; i++) {
     if (i % 7 === 0) {
       if (i > 0) weeks.push({ label: weekStart, value: weekSum });
-      weekStart = series[i].date.slice(5);
+      // дырка в ряду (бэк может не прислать точку за день) роняла всю страницу:
+      // «Cannot read properties of undefined (reading 'slice')». Соседний
+      // aggregateByWeekTwo уже защищён — приводим к тому же виду.
+      weekStart = (series[i]?.date ?? "").slice(5);
       weekSum = 0;
     }
     weekSum += series[i].value;


### PR DESCRIPTION
Страница аналитики падала целиком (белый/пустой экран) с ошибкой в консоли:

```
TypeError: Cannot read properties of undefined (reading 'slice')
```

`aggregateByWeek` обращался к `series[i].date` без проверки. Если бэкенд не прислал точку за какой-то день (пустой ряд, пропуск в выборке), падал весь SPA — React снимает дерево, остаётся пустой экран.

Соседняя функция `aggregateByWeekTwo` уже была написана безопасно (`(s1[i]?.date ?? s2[i]?.date ?? "").slice(5)`) — приводим `aggregateByWeek` к тому же виду.