### PR TITLE
fix(admin): белый экран в панели на Remnawave 3.x (у пользователя нет uuid)

### DIFF
--- a/frontend/src/components/admin/subscription-remna-panel.tsx
+++ b/frontend/src/components/admin/subscription-remna-panel.tsx
@@ -247,13 +247,18 @@ export function SubscriptionRemnaPanel({ subscription, token, remnaSquads, onCha
                   <span className="text-muted-foreground">ID Remna</span>
                   <span className="font-mono text-xs">{remnaUser.id ?? "—"}</span>
                 </div>
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">UUID</span>
-                  <span className="flex items-center gap-1">
-                    <code className="text-[10px]">{remnaUser.uuid.slice(0, 12)}…</code>
-                    <CopyButton text={remnaUser.uuid} />
-                  </span>
-                </div>
+                {/* В Remnawave 3.x поля uuid нет — пользователь адресуется
+                    числовым id (он показан строкой выше). Строку не рисуем,
+                    иначе обращение к undefined роняло всю панель. */}
+                {remnaUser.uuid && (
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">UUID</span>
+                    <span className="flex items-center gap-1">
+                      <code className="text-[10px]">{remnaUser.uuid.slice(0, 12)}…</code>
+                      <CopyButton text={remnaUser.uuid} />
+                    </span>
+                  </div>
+                )}
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">Трафик</span>
                   <span>
@@ -389,7 +394,7 @@ export function SubscriptionRemnaPanel({ subscription, token, remnaSquads, onCha
                         : "bg-muted border-transparent text-muted-foreground"
                     )}
                   >
-                    <span className="font-medium">{s.name || s.uuid.slice(0, 8)}</span>
+                    <span className="font-medium">{s.name || String(s.uuid ?? "").slice(0, 8) || "—"}</span>
                     {inSquad ? (
                       <Button
                         variant="ghost"

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -457,7 +457,7 @@ function NodeCard({
         <div className="flex items-start justify-between gap-3 mb-4">
           <div className="flex items-center gap-3 min-w-0">
             <div className="min-w-0">
-              <p className="font-semibold truncate">{node.name || node.uuid.substring(0, 8)}</p>
+              <p className="font-semibold truncate">{node.name || String(node.uuid ?? "").substring(0, 8) || "—"}</p>
               <p className="text-xs text-muted-foreground truncate">
                 {node.address}
                 {node.port != null ? `:${node.port}` : ""}

--- a/frontend/src/pages/remna-hosts.tsx
+++ b/frontend/src/pages/remna-hosts.tsx
@@ -391,7 +391,7 @@ export function RemnaHostsPage() {
               >
                 <option value="">Выберите инбаунд</option>
                 {(selectedProfile?.inbounds ?? []).map((ib) => (
-                  <option key={ib.uuid} value={ib.uuid}>{ib.tag ?? ib.uuid.slice(0, 8)}{ib.type ? ` · ${ib.type}` : ""}{ib.port ? ` · :${ib.port}` : ""}</option>
+                  <option key={ib.uuid} value={ib.uuid}>{ib.tag ?? String(ib.uuid ?? "").slice(0, 8)}{ib.type ? ` · ${ib.type}` : ""}{ib.port ? ` · :${ib.port}` : ""}</option>
                 ))}
               </select>
             </div>

--- a/frontend/src/pages/remna-nodes.tsx
+++ b/frontend/src/pages/remna-nodes.tsx
@@ -1506,7 +1506,7 @@ export function RemnaNodesPage() {
                   {(selectedProfile.inbounds ?? []).map((ib) => (
                     <label key={ib.uuid} className="flex items-center gap-2 cursor-pointer rounded-lg px-2 py-1.5 hover:bg-foreground/5">
                       <input type="checkbox" className="rounded accent-primary" checked={form.activeInbounds.includes(ib.uuid)} onChange={() => toggleInbound(ib.uuid)} />
-                      <span className="text-sm font-mono">{ib.tag ?? ib.uuid.slice(0, 8)}</span>
+                      <span className="text-sm font-mono">{ib.tag ?? String(ib.uuid ?? "").slice(0, 8)}</span>
                       {ib.type && <span className="text-[11px] font-semibold uppercase tracking-[0.5px] text-muted-foreground">{ib.type}{ib.port ? ` :${ib.port}` : ""}</span>}
                     </label>
                   ))}

--- a/frontend/src/pages/remna-profiles.tsx
+++ b/frontend/src/pages/remna-profiles.tsx
@@ -354,9 +354,9 @@ export function RemnaProfilesPage() {
                       )}
                     </div>
                     <div className="flex items-center gap-2 flex-wrap">
-                      <code className="font-mono text-[10px] text-muted-foreground/70">{p.uuid.slice(0, 8)}…</code>
+                      <code className="font-mono text-[10px] text-muted-foreground/70">{String(p.uuid ?? "").slice(0, 8)}…</code>
                       {(p.inbounds ?? []).map((ib) => (
-                        <code key={ib.uuid} className="font-mono text-[11px] bg-foreground/[0.04] dark:bg-white/[0.03] border border-border px-1.5 py-0.5 rounded text-muted-foreground">{ib.tag ?? ib.uuid.slice(0, 8)}{ib.port ? ` :${ib.port}` : ""}</code>
+                        <code key={ib.uuid} className="font-mono text-[11px] bg-foreground/[0.04] dark:bg-white/[0.03] border border-border px-1.5 py-0.5 rounded text-muted-foreground">{ib.tag ?? String(ib.uuid ?? "").slice(0, 8)}{ib.port ? ` :${ib.port}` : ""}</code>
                       ))}
                     </div>
                   </div>

--- a/frontend/src/pages/remna-squads.tsx
+++ b/frontend/src/pages/remna-squads.tsx
@@ -318,7 +318,7 @@ export function RemnaSquadsPage() {
                       {(p.inbounds ?? []).map((ib) => (
                         <label key={ib.uuid} className="flex items-center gap-2 cursor-pointer rounded-lg px-2 py-1.5 hover:bg-foreground/5">
                           <input type="checkbox" className="rounded accent-primary" checked={form.inbounds.includes(ib.uuid)} onChange={() => toggleInbound(ib.uuid)} />
-                          <span className="text-sm font-mono">{ib.tag ?? ib.uuid.slice(0, 8)}</span>
+                          <span className="text-sm font-mono">{ib.tag ?? String(ib.uuid ?? "").slice(0, 8)}</span>
                           {ib.type && <span className="text-[11px] font-semibold uppercase tracking-[0.5px] text-muted-foreground">{ib.type}{ib.port ? ` :${ib.port}` : ""}</span>}
                         </label>
                       ))}


### PR DESCRIPTION
Открываем карточку клиента → вкладка «Подписки» → вся админка становится пустым экраном. В консоли:

```
TypeError: Cannot read properties of undefined (reading 'slice')
```

## Причина

В Remnawave 3.x у пользователя **нет поля `uuid`** — он адресуется числовым `id`. А разметка обращалась к нему напрямую:

```tsx
<code>{remnaUser.uuid.slice(0, 12)}…</code>
```

Исключение во время рендера снимает всё дерево React — отсюда пустой экран вместо частичной поломки.

## Что поправлено

Строку «UUID» в карточке подписки на 3.x не показываем вовсе: числовой id уже выведен строкой выше, показывать нечего.

Те же незащищённые обращения нашлись ещё в семи местах и тоже закрыты — иначе белый экран ждал бы на других страницах:

- `pages/dashboard.tsx` — имя ноды;
- `pages/remna-nodes.tsx`, `pages/remna-squads.tsx`, `pages/remna-hosts.tsx` — теги inbound-ов;
- `pages/remna-profiles.tsx` — профили и их inbound-ы;
- `components/admin/subscription-remna-panel.tsx` — сквады подписки.

## Проверено

Собрано и выкачено на боевую установку с Remnawave 3.x: в бандле осталось одно обращение `.uuid.slice`, и оно теперь под проверкой `remnaUser.uuid && (…)`.