### PR TITLE
fix(remna): массовые операции над юзерами молча не применялись на Remnawave 3.x

### DIFF
--- a/backend/src/modules/remna/remna.client.ts
+++ b/backend/src/modules/remna/remna.client.ts
@@ -155,6 +155,18 @@ function toUserIds(ids: (string | number)[]): number[] {
   return ids.map((v) => Number(String(v).trim())).filter((v) => Number.isFinite(v) && v > 0);
 }
 
+/**
+ * Тело массовых ручек `/api/users/bulk/*`.
+ *
+ * ⚠️ Remnawave 3.x ждёт `userIds` МАССИВОМ ЧИСЕЛ; поля `uuids` больше нет —
+ * со старым телом ручка отвечает 400 «Validation failed», и массовая
+ * операция молча не применяется. На 2.x остаются строковые `uuids`.
+ */
+function bulkUserRef(ids: string[]): Record<string, unknown> {
+  const allNumeric = ids.length > 0 && ids.every((v) => /^\d+$/.test(String(v).trim()));
+  return allNumeric ? { userIds: toUserIds(ids) } : { uuids: ids };
+}
+
 export function extractRemnaUuid(d: unknown): string | null {
   if (!d || typeof d !== "object") return null;
   const o = d as Record<string, unknown>;
@@ -775,19 +787,19 @@ export function remnaGetHostTags() {
 
 /** POST /api/users/bulk/reset-traffic — сброс трафика пачке юзеров */
 export function remnaUsersBulkResetTraffic(uuids: string[]) {
-  return remnaFetch("/api/users/bulk/reset-traffic", { method: "POST", body: JSON.stringify({ uuids }) });
+  return remnaFetch("/api/users/bulk/reset-traffic", { method: "POST", body: JSON.stringify(bulkUserRef(uuids)) });
 }
 /** POST /api/users/bulk/revoke-subscription — перевыпуск подписки пачке */
 export function remnaUsersBulkRevoke(uuids: string[]) {
-  return remnaFetch("/api/users/bulk/revoke-subscription", { method: "POST", body: JSON.stringify({ uuids }) });
+  return remnaFetch("/api/users/bulk/revoke-subscription", { method: "POST", body: JSON.stringify(bulkUserRef(uuids)) });
 }
 /** POST /api/users/bulk/delete — удаление пачки юзеров из Remna */
 export function remnaUsersBulkDelete(uuids: string[]) {
-  return remnaFetch("/api/users/bulk/delete", { method: "POST", body: JSON.stringify({ uuids }) });
+  return remnaFetch("/api/users/bulk/delete", { method: "POST", body: JSON.stringify(bulkUserRef(uuids)) });
 }
 /** POST /api/users/bulk/update-squads — назначить сквады пачке */
 export function remnaUsersBulkUpdateSquads(uuids: string[], activeInternalSquads: string[]) {
-  return remnaFetch("/api/users/bulk/update-squads", { method: "POST", body: JSON.stringify({ uuids, activeInternalSquads }) });
+  return remnaFetch("/api/users/bulk/update-squads", { method: "POST", body: JSON.stringify({ ...bulkUserRef(uuids), activeInternalSquads }) });
 }
 
 /** GET /api/node-plugins — список плагинов нод */


### PR DESCRIPTION
Найдено сплошной сверкой всех вызовов Remnawave со спецификацией 3.2.1 — после того как по той же причине сломалось удаление устройства (#137).

## Проблема

Четыре массовые ручки в 3.x принимают `userIds` **массивом чисел**; поля `uuids` больше нет:

| ручка | схема 3.2.1 |
|---|---|
| `/api/users/bulk/delete` | `userIds: number[]` |
| `/api/users/bulk/reset-traffic` | `userIds: number[]` |
| `/api/users/bulk/revoke-subscription` | `userIds: number[]` |
| `/api/users/bulk/update-squads` | `userIds: number[]`, `activeInternalSquads: string[]` |

Мы слали `{ uuids }`. Ручка отвечает 400, и операция **молча не применяется**: администратор выделяет клиентов, жмёт «сбросить трафик» / «удалить» / «перевыпустить подписку» — и ничего не происходит.

## Что поправлено

Добавлен `bulkUserRef()` поверх уже существующего `toUserIds()`: если все идентификаторы числовые — уходит `userIds`, иначе прежние `uuids` для Remnawave 2.x.

## Проверено

Собрано и выкачено на боевую установку. Полный прогон массовой операции не делался: Remnawave у этого клиента сейчас недоступна по сети. Соответствие схеме сверено по спецификации.