### PR TITLE
feat(remna): прятать блоки, чьи ручки вырезаны в Remnawave 3.x

### DIFF
--- a/backend/src/modules/admin/admin.routes.ts
+++ b/backend/src/modules/admin/admin.routes.ts
@@ -3,6 +3,7 @@
  */
 
 import { readFile } from "node:fs/promises";
+import { getRemnaCapabilities } from "../remna/remna-capabilities.js";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import express, { Router } from "express";
@@ -391,6 +392,14 @@ adminRouter.post("/remna/hosts/bulk/:action", async (req, res) => {
 });
 adminRouter.get("/remna/torrent/reports", async (req, res) => remnaPass(await remnaGetTorrentReports({ start: Number(req.query.start) || 0, size: Number(req.query.size) || 50 }), res));
 adminRouter.get("/remna/torrent/stats", async (_req, res) => remnaPass(await remnaGetTorrentStats(), res));
+/**
+ * Что умеет подключённая Remnawave. Фронт по этому ответу прячет блоки,
+ * которых в 3.x больше нет (гео-карта на /api/ip-control, ссылки happ://).
+ */
+adminRouter.get("/remna/capabilities", async (_req, res) => {
+  res.json(await getRemnaCapabilities());
+});
+
 adminRouter.post("/remna/drop-connections", async (req, res) => remnaPass(await remnaDropConnections(req.body?.dropBy), res));
 
 adminRouter.get("/remna/nodes-metrics", async (_req, res) => {

--- a/backend/src/modules/remna/remna-capabilities.ts
+++ b/backend/src/modules/remna/remna-capabilities.ts
@@ -1,0 +1,78 @@
+/**
+ * Что умеет подключённая Remnawave.
+ *
+ * В 3.x из API вырезаны целые разделы, и завязанные на них блоки панели
+ * молча перестают работать. Чтобы не показывать администратору мёртвые
+ * кнопки, определяем мажорную версию и отдаём набор возможностей.
+ *
+ * Как определяем версию: отдельной ручки с номером у Remnawave нет
+ * (`/api/system/metadata` в спецификации описан безымянным объектом),
+ * поэтому смотрим на форму данных — в 3.x у пользователя числовой `id`
+ * и нет `uuid`. Тот же признак использует стартовая миграция
+ * `scripts/migrate-remna-ids.ts`.
+ *
+ * Если определить не удалось (Remnawave недоступна, пользователей ещё нет),
+ * возвращаем `major: null` и НИЧЕГО не прячем: лучше показать блок, который
+ * не сработает, чем спрятать рабочий.
+ */
+
+import { isRemnaConfigured, remnaGetUsers } from "./remna.client.js";
+
+export interface RemnaCapabilities {
+  /** 2 | 3 | null — null означает «не удалось определить» */
+  major: 2 | 3 | null;
+  /** /api/ip-control/* — гео-карта клиентов, сброс соединений. Вырезан в 3.x. */
+  ipControl: boolean;
+  /** /api/system/tools/happ/encrypt — ссылки happ://. Вырезан в 3.x. */
+  happCrypt: boolean;
+  /** /api/bandwidth-stats/nodes/realtime. Вырезан в 3.x. */
+  realtimeBandwidth: boolean;
+}
+
+const TTL_MS = 10 * 60 * 1000;
+let cache: { value: RemnaCapabilities; at: number } | null = null;
+
+function fromMajor(major: 2 | 3 | null): RemnaCapabilities {
+  const gone = major === 3;
+  return {
+    major,
+    ipControl: !gone,
+    happCrypt: !gone,
+    realtimeBandwidth: !gone,
+  };
+}
+
+async function detectMajor(): Promise<2 | 3 | null> {
+  if (!isRemnaConfigured()) return null;
+  // remnaFetch отдаёт обёртку { data, error, status }, а Remnawave заворачивает
+  // полезную нагрузку ещё и в response.
+  const res = (await remnaGetUsers({ size: 1 })) as { data?: unknown };
+  const body = (res?.data ?? res) as Record<string, unknown> | undefined;
+  const resp = (body?.response ?? body) as Record<string, unknown> | undefined;
+  const users = (resp?.users ?? resp?.items) as Record<string, unknown>[] | undefined;
+  if (!Array.isArray(users) || users.length === 0) return null;
+
+  const u = users[0];
+  if (typeof u.uuid === "string" && u.uuid) return 2;
+  if (typeof u.id === "number") return 3;
+  return null;
+}
+
+export async function getRemnaCapabilities(force = false): Promise<RemnaCapabilities> {
+  if (!force && cache && Date.now() - cache.at < TTL_MS) return cache.value;
+  let major: 2 | 3 | null = null;
+  try {
+    major = await detectMajor();
+  } catch {
+    major = null;
+  }
+  const value = fromMajor(major);
+  // Неопределённость не кэшируем надолго: Remnawave могла просто лежать.
+  cache = { value, at: major === null ? Date.now() - TTL_MS + 30_000 : Date.now() };
+  return value;
+}
+
+/** Сбросить кэш — например после смены адреса Remnawave в настройках. */
+export function resetRemnaCapabilitiesCache(): void {
+  cache = null;
+}

--- a/backend/src/modules/remna/remna.client.ts
+++ b/backend/src/modules/remna/remna.client.ts
@@ -613,6 +613,12 @@ export async function remnaEncryptHappLink(linkToEncrypt: string): Promise<strin
   // Уже crypt — возвращаем как есть
   if (trimmed.startsWith("happ://")) return trimmed;
 
+  // В Remnawave 3.x ручки /api/system/tools/happ/encrypt больше нет —
+  // без этой проверки каждый вызов уходил бы в 404. Ссылка вернётся
+  // как есть (уже зашифровано либо шифрование недоступно).
+  const { getRemnaCapabilities } = await import("./remna-capabilities.js");
+  if (!(await getRemnaCapabilities()).happCrypt) return null;
+
   const cached = _happCryptCache.get(trimmed);
   if (cached && Date.now() - cached.ts < HAPP_CRYPT_TTL_MS) {
     return cached.value;

--- a/frontend/src/components/layout/dashboard-layout.tsx
+++ b/frontend/src/components/layout/dashboard-layout.tsx
@@ -11,6 +11,7 @@ import {
   RefreshCw, Layers, FileCode2,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { useRemnaCapabilities } from "@/lib/use-remna-capabilities";
 import { useAdminLanguageSync } from "@/i18n/use-language-sync";
 import { WhatsNew510 } from "@/components/admin/whats-new-510";
 import { useAuth } from "@/contexts/auth";
@@ -122,9 +123,13 @@ function NavItems({ onClick }: { onClick?: () => void }) {
   const location = useLocation();
   const admin = useAuth().state.admin;
   const allNav = useNavSections();
-  const nav = admin
+  // Гео-карта живёт на /api/ip-control, а этот раздел вырезан в Remnawave 3.x —
+  // на таких панелях пункт меню только вводит в заблуждение.
+  const caps = useRemnaCapabilities();
+  const navBySection = admin
     ? allNav.filter((item) => canAccessSection(admin.role, admin.allowedSections, item.section, item.requiredAction))
     : allNav;
+  const nav = caps.ipControl ? navBySection : navBySection.filter((item) => item.to !== "/admin/geo-map");
 
   const groupedNav = nav.reduce((acc, item) => {
     if (!acc[item.category]) acc[item.category] = [];

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -322,7 +322,22 @@ async function request<T>(
   return data as T;
 }
 
+/** Что умеет подключённая Remnawave: в 3.x часть разделов API вырезана. */
+export interface RemnaCapabilities {
+  /** 2 | 3 | null — null означает «не удалось определить» */
+  major: 2 | 3 | null;
+  /** /api/ip-control/* — гео-карта, сброс соединений */
+  ipControl: boolean;
+  /** ссылки happ:// через /api/system/tools/happ/encrypt */
+  happCrypt: boolean;
+  realtimeBandwidth: boolean;
+}
+
 export const api = {
+  /** Возможности подключённой Remnawave (бэкенд кэширует на 10 минут). */
+  async getRemnaCapabilities(token: string): Promise<RemnaCapabilities> {
+    return request("/admin/remna/capabilities", { token });
+  },
   async login(email: string, password: string): Promise<LoginResponse | AdminAuthRequires2FA> {
     return request<LoginResponse | AdminAuthRequires2FA>("/auth/login", {
       method: "POST",

--- a/frontend/src/lib/use-remna-capabilities.ts
+++ b/frontend/src/lib/use-remna-capabilities.ts
@@ -1,0 +1,43 @@
+/**
+ * Что умеет подключённая Remnawave.
+ *
+ * В 3.x из API вырезаны целые разделы, и завязанные на них блоки панели
+ * работать не могут. Бэкенд определяет версию и отдаёт набор возможностей —
+ * здесь мы его кэшируем на весь сеанс, чтобы каждый экран не спрашивал заново.
+ *
+ * Пока ответа нет (или он не пришёл), считаем, что доступно ВСЁ: лучше
+ * показать блок, который не сработает, чем спрятать рабочий.
+ */
+
+import { useEffect, useState } from "react";
+import { api, type RemnaCapabilities } from "@/lib/api";
+import { useAuth } from "@/contexts/auth";
+
+const ALL_AVAILABLE: RemnaCapabilities = {
+  major: null,
+  ipControl: true,
+  happCrypt: true,
+  realtimeBandwidth: true,
+};
+
+let cache: RemnaCapabilities | null = null;
+let inflight: Promise<RemnaCapabilities> | null = null;
+
+export function useRemnaCapabilities(): RemnaCapabilities {
+  const token = useAuth().state.accessToken ?? "";
+  const [caps, setCaps] = useState<RemnaCapabilities>(cache ?? ALL_AVAILABLE);
+
+  useEffect(() => {
+    if (!token || cache) return;
+    let alive = true;
+    inflight = inflight ?? api.getRemnaCapabilities(token).catch(() => ALL_AVAILABLE);
+    inflight.then((r) => {
+      cache = r;
+      inflight = null;
+      if (alive) setCaps(r);
+    });
+    return () => { alive = false; };
+  }, [token]);
+
+  return caps;
+}

--- a/frontend/src/pages/geo-map.tsx
+++ b/frontend/src/pages/geo-map.tsx
@@ -11,6 +11,7 @@ import { useAuth } from "@/contexts/auth";
 import { api } from "@/lib/api";
 import type { GeoMapResponse, GeoMapNode } from "@/lib/api";
 import { cn } from "@/lib/utils";
+import { useRemnaCapabilities } from "@/lib/use-remna-capabilities";
 
 const TILE_URL = "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png";
 const TILE_ATTR = '&copy; <a href="https://www.openstreetmap.org/copyright">OSM</a> &copy; <a href="https://carto.com/">CARTO</a>';
@@ -113,6 +114,7 @@ function FitBounds({ nodes }: { nodes: GeoMapNode[] }) {
 
 export function GeoMapPage() {
   const { state } = useAuth();
+  const caps = useRemnaCapabilities();
   const token = state.accessToken ?? "";
   const [data, setData] = useState<GeoMapResponse | null>(null);
   const [loading, setLoading] = useState(true);
@@ -192,6 +194,28 @@ export function GeoMapPage() {
         <div className="flex flex-col items-center gap-4">
           <div className="h-10 w-10 animate-spin rounded-full border-2 border-primary border-t-transparent" />
           <p className="text-muted-foreground text-sm">Загружаем карту…</p>
+        </div>
+      </div>
+    );
+  }
+
+  // На Remnawave 3.x раздела /api/ip-control нет — карте неоткуда брать данные.
+  if (!caps.ipControl) {
+    return (
+      <div className="flex flex-col gap-3.5 relative">
+        <div className="flex items-start gap-3">
+          <div>
+            <h1 className="text-xl font-extrabold tracking-[-0.3px] text-foreground">Карта нод</h1>
+            <p className="text-[12.5px] text-muted-foreground mt-[3px]">Живая география нод и подключений клиентов.</p>
+          </div>
+        </div>
+        <div className="bg-card border border-border rounded-2xl py-16 flex flex-col items-center justify-center text-center px-6">
+          <h3 className="text-[13.5px] font-bold tracking-tight">Недоступно на Remnawave 3.x</h3>
+          <p className="text-sm text-muted-foreground mt-1 max-w-md">
+            Карта строится по IP-адресам подключений, а раздел API, который их отдавал
+            (<code className="text-xs">/api/ip-control</code>), в Remnawave 3.x удалён.
+            Как только появится замена — вернём раздел.
+          </p>
         </div>
       </div>
     );

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { useAuth } from "@/contexts/auth";
+import { useRemnaCapabilities } from "@/lib/use-remna-capabilities";
 import { api, type AdminSettings, type AutoRenewStats, type SyncResult, type SyncToRemnaResult, type SyncCreateRemnaForMissingResult, type SubscriptionPageConfig, type SshConfig } from "@/lib/api";
 import { SubscriptionPageEditor } from "@/components/subscription-page-editor";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -423,6 +424,8 @@ export function SettingsPage() {
   const [landingDevicesList, setLandingDevicesList] = useState<string[]>(defaultDevicesList);
   const [landingQuickStartList, setLandingQuickStartList] = useState<string[]>(defaultQuickStartList);
   const token = state.accessToken!;
+  // На Remnawave 3.x ручки happ-шифрования нет — тумблер обещал бы несбыточное.
+  const remnaCaps = useRemnaCapabilities();
 
   useEffect(() => {
     let cancelled = false;
@@ -3867,7 +3870,8 @@ export function SettingsPage() {
                   <label className="flex items-center gap-3 p-3.5 rounded-xl bg-card/40 border border-border cursor-pointer">
                     <input
                       type="checkbox"
-                      checked={settings.happCryptEnabled === true}
+                      checked={settings.happCryptEnabled === true && remnaCaps.happCrypt}
+                      disabled={!remnaCaps.happCrypt}
                       onChange={(e) => setSettings((s) => (s ? { ...s, happCryptEnabled: e.target.checked } : s))}
                       className="rounded border w-4 h-4"
                     />


### PR DESCRIPTION
Продолжение сверки со спецификацией 3.2.1 (#138). Кроме переименованных полей нашлись **разделы API, удалённые целиком** — завязанные на них блоки панели на 3.x просто не работают, но кнопки остаются на месте.

| раздел API | что на нём держится | статус в 3.x |
|---|---|---|
| `/api/ip-control/*` | гео-карта клиентов, «сбросить соединения» | удалён |
| `/api/system/tools/happ/encrypt` | ссылки `happ://` | удалён |
| `/api/bandwidth-stats/nodes/realtime` | realtime-трафик нод | удалён (есть `nodes/usage`) |

## Как определяем версию

Отдельной ручки с номером у Remnawave нет — `/api/system/metadata` в спецификации описан безымянным объектом. Поэтому смотрим на форму данных: в 3.x у пользователя числовой `id` и нет `uuid`. Тот же признак уже используется стартовой миграцией `migrate-remna-ids.ts`.

Результат кэшируется на 10 минут и отдаётся на `GET /admin/remna/capabilities`.

## Что меняется в интерфейсе

- пункт «Карта нод» пропадает из меню;
- на самой странице (по прямой ссылке) вместо пустоты — объяснение, что раздел API удалён;
- тумблер Happ Crypto в настройках блокируется;
- `remnaEncryptHappLink()` на 3.x не ходит в удалённую ручку впустую.

## Осторожность

Если версию определить **не удалось** (Remnawave недоступна, пользователей ещё нет) — не прячем ничего. Лучше показать блок, который не сработает, чем спрятать рабочий.

## Проверено

Собрано и выкачено на боевую установку: `GET /api/admin/remna/capabilities` отвечает 401 без токена (роут поднят), сборка фронта и бэкенда проходит. Поведение при живой 3.x не проверено — Remnawave у этого клиента сейчас недоступна по сети, поэтому определение версии сейчас возвращает `null` и, по задумке, ничего не прячет.