### PR TITLE
feat(payments): платёжный провайдер RollyPay (СБП, карты, крипта → USDT)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -20,6 +20,7 @@ import { yoomoneyWebhooksRouter } from "./modules/webhooks/yoomoney.webhooks.rou
 import { yookassaWebhooksRouter } from "./modules/webhooks/yookassa.webhooks.routes.js";
 import { cryptopayWebhooksRouter } from "./modules/webhooks/cryptopay.webhooks.routes.js";
 import { heleketWebhooksRouter } from "./modules/webhooks/heleket.webhooks.routes.js";
+import { rollypayWebhooksRouter } from "./modules/webhooks/rollypay.webhooks.routes.js";
 import { lavaWebhooksRouter } from "./modules/webhooks/lava.webhooks.routes.js";
 import { lavatopWebhooksRouter } from "./modules/webhooks/lavatop.webhooks.routes.js";
 import { botAdminRouter } from "./modules/bot-admin/bot-admin.routes.js";
@@ -132,6 +133,8 @@ app.use(cors({
 // Crypto Pay, Heleket и Lava webhooks нужен raw body для проверки подписи (до express.json)
 app.use("/api/webhooks/cryptopay", express.raw({ type: "application/json" }), cryptopayWebhooksRouter);
 app.use("/api/webhooks/heleket", express.raw({ type: "application/json" }), heleketWebhooksRouter);
+// RollyPay подписывает СЫРОЕ тело — express.raw обязателен, иначе подпись не сойдётся.
+app.use("/api/webhooks/rollypay", express.raw({ type: "application/json" }), rollypayWebhooksRouter);
 app.use("/api/webhooks/lava", express.raw({ type: "application/json" }), lavaWebhooksRouter);
 // Platega — HMAC проверяет raw body. Apply path-specific raw middleware ДО express.json,
 // чтобы плательщик мог проверить подпись над оригинальными байтами. Сам router смонтирован

--- a/backend/src/modules/admin/admin.routes.ts
+++ b/backend/src/modules/admin/admin.routes.ts
@@ -2929,6 +2929,9 @@ const updateSettingsSchema = z.object({
   cryptopayTestnet: z.boolean().optional(),
   heleketMerchantId: z.string().max(500).nullable().optional(),
   heleketApiKey: z.string().max(500).nullable().optional(),
+  rollypayApiKey: z.string().max(500).nullable().optional(),
+  rollypaySigningSecret: z.string().max(500).nullable().optional(),
+  rollypayTestMode: z.boolean().optional(),
   lavaShopId: z.string().max(200).nullable().optional(),
   lavaSecretKey: z.string().max(500).nullable().optional(),
   lavaAdditionalKey: z.string().max(500).nullable().optional(),
@@ -3511,6 +3514,18 @@ adminRouter.patch("/settings", async (req, res) => {
   if (updates.heleketMerchantId !== undefined) {
     const val = updates.heleketMerchantId ?? "";
     await prisma.systemSetting.upsert({ where: { key: "heleket_merchant_id" }, create: { key: "heleket_merchant_id", value: val }, update: { value: val } });
+  }
+  if (updates.rollypayApiKey !== undefined) {
+    const val = updates.rollypayApiKey ?? "";
+    await prisma.systemSetting.upsert({ where: { key: "rollypay_api_key" }, create: { key: "rollypay_api_key", value: val }, update: { value: val } });
+  }
+  if (updates.rollypaySigningSecret !== undefined) {
+    const val = updates.rollypaySigningSecret ?? "";
+    await prisma.systemSetting.upsert({ where: { key: "rollypay_signing_secret" }, create: { key: "rollypay_signing_secret", value: val }, update: { value: val } });
+  }
+  if (updates.rollypayTestMode !== undefined) {
+    const val = updates.rollypayTestMode ? "true" : "false";
+    await prisma.systemSetting.upsert({ where: { key: "rollypay_test_mode" }, create: { key: "rollypay_test_mode", value: val }, update: { value: val } });
   }
   if (updates.heleketApiKey !== undefined) {
     const val = updates.heleketApiKey ?? "";

--- a/backend/src/modules/client/client.routes.ts
+++ b/backend/src/modules/client/client.routes.ts
@@ -42,6 +42,7 @@ import { getAuthUrl, exchangeCodeForToken, requestPayment, processPayment } from
 import { createYookassaPayment } from "../yookassa/yookassa.service.js";
 import { createCryptopayInvoice, isCryptopayConfigured } from "../cryptopay/cryptopay.service.js";
 import { createHeleketInvoice, isHeleketConfigured } from "../heleket/heleket.service.js";
+import { createRollypayPayment, isRollypayConfigured } from "../rollypay/rollypay.service.js";
 import { createLavaInvoice, isLavaConfigured } from "../lava/lava.service.js";
 import { createLavatopInvoice, isLavatopConfigured } from "../lavatop/lavatop.service.js";
 import { createOverpayPayformOrder, isOverpayConfigured } from "../overpay/overpay.service.js";
@@ -6125,6 +6126,261 @@ clientRouter.post("/heleket/create-payment", async (req, res) => {
   }
 });
 
+clientRouter.post("/rollypay/create-payment", async (req, res) => {
+  try {
+    const clientId = (req as unknown as { clientId: string }).clientId;
+    const parsed = heleketCreatePaymentSchema.safeParse(req.body);
+    if (!parsed.success) return res.status(400).json({ message: "Неверные параметры", errors: parsed.error.flatten() });
+    const config = await getSystemConfig();
+    const rollypayConfig = {
+      apiKey: (config as { rollypayApiKey?: string | null }).rollypayApiKey ?? "",
+      signingSecret: (config as { rollypaySigningSecret?: string | null }).rollypaySigningSecret ?? "",
+      testMode: (config as { rollypayTestMode?: boolean }).rollypayTestMode === true,
+    };
+    if (!isRollypayConfigured(rollypayConfig)) return res.status(503).json({ message: "RollyPay не настроен" });
+    const { extendsSecondarySubId, removeExtrasOnActivate, asGift, asAdditional } = parsed.data;
+
+    const { amount: amountBody, currency: currencyBody, tariffId: tariffIdBody, proxyTariffId: proxyTariffIdBody, singboxTariffId: singboxTariffIdBody, promoCode: promoCodeStr, extraOption, customBuild: customBuildBody } = parsed.data;
+    let amountRounded: number;
+    let currencyUpper: string;
+    let tariffIdToStore: string | null = null;
+    let proxyTariffIdToStore: string | null = null;
+    let singboxTariffIdToStore: string | null = null;
+    let metadataObj: Record<string, unknown> = promoCodeStr ? { promoCode: promoCodeStr } : {};
+
+    if (customBuildBody) {
+      const cfg = getCustomBuildConfig(config);
+      if (!cfg) return res.status(400).json({ message: "Гибкий тариф отключён" });
+      let { days, devices, trafficGb } = customBuildBody;
+      if (days > cfg.maxDays || devices > cfg.maxDevices) {
+        return res.status(400).json({ message: `Дни: 1–${cfg.maxDays}, устройств: 1–${cfg.maxDevices}` });
+      }
+      const trafficLimitBytes =
+        cfg.trafficMode === "per_gb" && trafficGb != null && trafficGb >= 0
+          ? Math.round(trafficGb * 1024 ** 3)
+          : null;
+      amountRounded = days * cfg.pricePerDay + devices * cfg.pricePerDevice;
+      if (cfg.trafficMode === "per_gb" && trafficGb != null && trafficGb > 0) amountRounded += trafficGb * cfg.pricePerGb;
+      amountRounded = Math.round(amountRounded * 100) / 100;
+      currencyUpper = cfg.currency.toUpperCase();
+      metadataObj = {
+        customBuild: {
+          durationDays: days,
+          deviceLimit: devices,
+          trafficLimitBytes,
+          internalSquadUuids: [cfg.squadUuid],
+        },
+      };
+    } else if (extraOption) {
+      const cfg = config as { sellOptionsEnabled?: boolean; sellOptionsTrafficEnabled?: boolean; sellOptionsTrafficProducts?: SellOptionTrafficProduct[]; sellOptionsDevicesEnabled?: boolean; sellOptionsDevicesProducts?: SellOptionDeviceProduct[]; sellOptionsServersEnabled?: boolean; sellOptionsServersProducts?: SellOptionServerProduct[] };
+      if (!cfg.sellOptionsEnabled) return res.status(400).json({ message: "Продажа опций отключена" });
+      if (extraOption.kind === "traffic") {
+        const product = cfg.sellOptionsTrafficEnabled && cfg.sellOptionsTrafficProducts?.find((p) => p.id === extraOption.productId);
+        if (!product) return res.status(400).json({ message: "Опция не найдена" });
+        amountRounded = Math.round(product.price * 100) / 100;
+        currencyUpper = product.currency.toUpperCase();
+        metadataObj = { extraOption: { kind: "traffic", trafficBytes: Math.round(product.trafficGb * 1024 ** 3) } };
+      } else if (extraOption.kind === "devices") {
+        const product = cfg.sellOptionsDevicesEnabled && cfg.sellOptionsDevicesProducts?.find((p) => p.id === extraOption.productId);
+        if (!product) return res.status(400).json({ message: "Опция не найдена" });
+        // масштабируем цену для primary подписки
+        const prorataCoef = extraOption.targetSubscriptionId ? await calculateDevicesProrataPriceCoefficient(extraOption.targetSubscriptionId) : await calculateDevicesProrataPriceCoefficientForPrimary(clientId);
+        amountRounded = Math.floor(product.price * prorataCoef);
+        currencyUpper = product.currency.toUpperCase();
+        metadataObj = { extraOption: { kind: "devices", deviceCount: product.deviceCount, productPriceMonthly: product.price } };
+      } else {
+        const product = cfg.sellOptionsServersEnabled && cfg.sellOptionsServersProducts?.find((p) => p.id === extraOption.productId);
+        if (!product) return res.status(400).json({ message: "Опция не найдена" });
+        amountRounded = Math.round(product.price * 100) / 100;
+        currencyUpper = product.currency.toUpperCase();
+        metadataObj = { extraOption: { kind: "servers", squadUuid: product.squadUuid, ...((product.trafficGb ?? 0) > 0 && { trafficBytes: Math.round((product.trafficGb ?? 0) * 1024 ** 3) }) } };
+      }
+    } else {
+      currencyUpper = (currencyBody ?? "USD").toUpperCase();
+      if (tariffIdBody) {
+        const tariff = await prisma.tariff.findUnique({
+          where: { id: tariffIdBody },
+          include: { priceOptions: true },
+        });
+        if (!tariff) return res.status(400).json({ message: "Тариф не найден" });
+        // кулдаун ПРОДЛЕНИЯ существующей подписки.
+        // Применяется только при продлении (extendsSecondarySubId) — новые покупки этого
+        // же тарифа как доп. подписок не блокируются.
+        if ("extendsSecondarySubId" in parsed.data && parsed.data.extendsSecondarySubId) {
+          const { checkSubscriptionRenewalCooldown } = await import("../tariff/tariff-cooldown.service.js");
+          const cd = await checkSubscriptionRenewalCooldown(parsed.data.extendsSecondarySubId!);
+          if (!cd.ok) return res.status(429).json({ message: cd.message, code: "TARIFF_COOLDOWN", daysLeft: cd.daysLeft });
+        }
+        tariffIdToStore = tariffIdBody;
+        // честный расчёт цены тарифа.
+        // Раньше: `amountBody ?? tariff.price` — игнорировались priceOption и extras (баг 149₽).
+        // Теперь: priceOption + extras (новая покупка) или extrasMonthlyPrice (продление).
+        let unitPriceCalc = tariff.price;
+        let effectiveDaysCalc = tariff.durationDays;
+        if (parsed.data.tariffPriceOptionId) {
+          const opt = (tariff.priceOptions ?? []).find((p) => p.id === parsed.data.tariffPriceOptionId);
+          if (opt) {
+            unitPriceCalc = opt.price;
+            effectiveDaysCalc = opt.durationDays;
+          }
+        }
+        // доплата за СУЩЕСТВУЮЩИЕ extras подписки при продлении.
+        // T-extras-universal: при «убрать устройства» (removeExtrasOnActivate) доплату НЕ берём —
+        // устройства удаляются при активации, юзер видел базовую цену.
+        if (parsed.data.extendsSecondarySubId && parsed.data.removeExtrasOnActivate !== true) {
+          const sub = await prisma.subscription.findUnique({
+            where: { id: parsed.data.extendsSecondarySubId },
+            select: { extraDevicesMonthlyPrice: true },
+          });
+          const monthlyPrice = sub?.extraDevicesMonthlyPrice ?? 0;
+          if (monthlyPrice > 0 && effectiveDaysCalc > 0) {
+            unitPriceCalc += Math.round(monthlyPrice * (effectiveDaysCalc / 30) * 100) / 100;
+          }
+        }
+        // НОВЫЕ устройства, выбранные при покупке — теперь для ЛЮБОЙ покупки
+        // (новая/конверт/продление): activation их честно выдаёт, значит и цена честная.
+        {
+          const newExtrasCalc = Math.max(0, parsed.data.deviceCount ?? 0);
+          if (newExtrasCalc > 0) {
+            const { calcExtrasPrice } = await import("../tariff/extras-pricing.js");
+            const r = calcExtrasPrice(
+              tariff.pricePerExtraDevice ?? 0,
+              newExtrasCalc,
+              tariff.deviceDiscountTiers,
+              effectiveDaysCalc,
+            );
+            unitPriceCalc += r.extrasTotal;
+          }
+        }
+        amountRounded = Math.round(unitPriceCalc * 100) / 100;
+      } else if (proxyTariffIdBody) {
+        const proxyTariff = await prisma.proxyTariff.findUnique({ where: { id: proxyTariffIdBody } });
+        if (!proxyTariff || !proxyTariff.enabled) return res.status(400).json({ message: "Прокси-тариф не найден" });
+        proxyTariffIdToStore = proxyTariffIdBody;
+        amountRounded = Math.round((amountBody ?? proxyTariff.price) * 100) / 100;
+      } else if (singboxTariffIdBody) {
+        const singboxTariff = await prisma.singboxTariff.findUnique({ where: { id: singboxTariffIdBody } });
+        if (!singboxTariff || !singboxTariff.enabled) return res.status(400).json({ message: "Тариф Sing-box не найден" });
+        singboxTariffIdToStore = singboxTariffIdBody;
+        amountRounded = Math.round((amountBody ?? singboxTariff.price) * 100) / 100;
+      } else {
+        if (amountBody == null) return res.status(400).json({ message: "Укажите сумму" });
+        amountRounded = Math.round(amountBody * 100) / 100;
+      }
+    }
+
+    if (amountRounded < 1) return res.status(400).json({ message: "Минимальная сумма платежа — 1" });
+
+    // Персональная скидка админа — на продуктовые оплаты, не на чистое пополнение.
+    const rollypayIsTopup = !tariffIdToStore && !proxyTariffIdToStore && !singboxTariffIdToStore && !customBuildBody && !extraOption;
+    if (!rollypayIsTopup) {
+      const originalBeforePersonal = amountRounded;
+      const pd = await applyPersonalDiscount(amountRounded, clientId);
+      if (pd.personalDiscountPercent > 0) {
+        amountRounded = pd.amount;
+        metadataObj = { ...metadataObj, personalDiscountPercent: pd.personalDiscountPercent, originalAmount: originalBeforePersonal };
+      }
+    }
+
+    // Применяем промокод на скидку (не для опций и гибких тарифов)
+    let promoCodeRecord: { id: string } | null = null;
+    if (promoCodeStr?.trim() && !extraOption && !customBuildBody) {
+      const result = await validatePromoCode(promoCodeStr.trim(), clientId);
+      if (!result.ok) return res.status(result.status).json({ message: result.error });
+      const promo = result.promo;
+      if (promo.type !== "DISCOUNT") return res.status(400).json({ message: "Этот промокод не даёт скидку на оплату" });
+      const originalAmount = (metadataObj as { originalAmount?: number }).originalAmount ?? amountRounded;
+      if (promo.discountPercent && promo.discountPercent > 0) {
+        amountRounded = Math.max(0, amountRounded - amountRounded * promo.discountPercent / 100);
+      }
+      if (promo.discountFixed && promo.discountFixed > 0) {
+        amountRounded = Math.max(0, amountRounded - promo.discountFixed);
+      }
+      amountRounded = Math.round(amountRounded * 100) / 100;
+      if (amountRounded <= 0) return res.status(400).json({ message: "Итоговая сумма не может быть 0" });
+      promoCodeRecord = promo;
+      metadataObj = { ...metadataObj, promoCodeId: promo.id, originalAmount };
+    }
+
+    const rpSnap = rollypayIsTopup ? await paymentSnapshotTopup(clientId, amountRounded) : await paymentSnapshotProduct(clientId, amountRounded);
+    const rpCharge = rpSnap.amount;
+
+    const orderId = randomUUID();
+    const payment = await createPayment({
+      data: asPaymentUncheckedCreate({
+        clientId,
+        orderId,
+        amount: rpSnap.amount,
+        currency: currencyUpper,
+        status: "PENDING",
+        provider: "rollypay",
+        tariffId: tariffIdToStore,
+        tariffPriceOptionId: parsed.data.tariffPriceOptionId ?? null,
+        deviceCount: parsed.data.deviceCount ?? null,
+        proxyTariffId: proxyTariffIdToStore,
+        singboxTariffId: singboxTariffIdToStore,
+        // see yookassa endpoint for explanation.
+        metadata: (() => {
+          const meta = { ...metadataObj };
+          if (asAdditional && tariffIdToStore) {
+            meta.isAdditionalSubscription = true;
+          }
+          if (asGift) {
+            meta.purchasedAsGift = true;
+          }
+          if (extendsSecondarySubId) {
+            meta.extendsSecondarySubId = extendsSecondarySubId;
+            // флаг удаления доп. устройств при активации.
+            if (removeExtrasOnActivate === true) {
+              meta.removeExtrasOnActivate = true;
+            }
+            // замена выбранного триала при покупке.
+            if (parsed.data.replaceTrialSubId) {
+              meta.replaceTrialSubId = parsed.data.replaceTrialSubId;
+            }
+          }
+          return Object.keys(meta).length > 0 ? JSON.stringify(meta) : null;
+        })(),
+      }),
+    });
+
+    const serviceName = config.serviceName?.trim() || "STEALTHNET";
+    const appUrl = (config.publicAppUrl || "").replace(/\/$/, "");
+    // Адрес вебхука у RollyPay задаётся в личном кабинете кассы, в запросе его нет:
+    // указать нужно {publicAppUrl}/api/webhooks/rollypay
+    const urlSuccess = appUrl ? `${appUrl}/cabinet?rollypay=success` : undefined;
+    const urlFail = appUrl ? `${appUrl}/cabinet?rollypay=fail` : undefined;
+
+    const result = await createRollypayPayment({
+      config: rollypayConfig,
+      amount: String(rpCharge),
+      currency: currencyUpper,
+      orderId,
+      description: `Оплата ${orderId}`,
+      customerId: clientId,
+      successRedirectUrl: urlSuccess,
+      failRedirectUrl: urlFail,
+      metadata: { paymentId: payment.id },
+    });
+
+    if (!result.ok) {
+      await prisma.payment.delete({ where: { id: payment.id } }).catch(() => {});
+      return res.status(500).json({ message: result.error });
+    }
+
+    const payUrl = await saveRedirectAndBuildUrl(payment.id, orderId, result.url, config.publicAppUrl);
+
+    return res.status(201).json({
+      paymentId: payment.id,
+      payUrl,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[rollypay/create-payment]", message, err);
+    return res.status(500).json({ message: message || "Ошибка создания платежа" });
+  }
+});
+
 // ═════════════════════════════════════════════════════════════════
 // LAVA Business — счета (карты / СБП / СберPay) в рублях.
 // API: POST https://api.lava.ru/business/invoice/create
@@ -7065,6 +7321,7 @@ clientRouter.post("/ai/chat", async (req, res) => {
     if (publicConfig.yoomoneyEnabled) paymentMethods.push("YooMoney (Кошелек, Карты)");
     if (publicConfig.cryptopayEnabled) paymentMethods.push("Crypto Pay (Криптовалюта в Telegram)");
     if (publicConfig.heleketEnabled) paymentMethods.push("Heleket (Криптовалюта)");
+    if ((publicConfig as { rollypayEnabled?: boolean }).rollypayEnabled) paymentMethods.push("RollyPay (СБП, карты, крипта)");
     if (publicConfig.plategaMethods && publicConfig.plategaMethods.length > 0) {
       paymentMethods.push("Platega (" + publicConfig.plategaMethods.map(m => m.label).join(", ") + ")");
     }

--- a/backend/src/modules/client/client.service.ts
+++ b/backend/src/modules/client/client.service.ts
@@ -126,6 +126,7 @@ const SYSTEM_CONFIG_KEYS = [
   "yookassa_webhook_basic_user", "yookassa_webhook_basic_password",
   "cryptopay_api_token", "cryptopay_testnet",
   "heleket_merchant_id", "heleket_api_key",
+  "rollypay_api_key", "rollypay_signing_secret", "rollypay_test_mode",
   "lava_shop_id", "lava_secret_key", "lava_additional_key",
   "lavatop_api_key", "lavatop_default_offer_id",
   "overpay_api_url", "overpay_project_id", "overpay_login", "overpay_password",
@@ -671,6 +672,9 @@ async function loadSystemConfigFromDb() {
     cryptopayTestnet: map.cryptopay_testnet === "true" || map.cryptopay_testnet === "1",
     heleketMerchantId: (map.heleket_merchant_id ?? "").trim() || null,
     heleketApiKey: (map.heleket_api_key ?? "").trim() || null,
+    rollypayApiKey: (map.rollypay_api_key ?? "").trim() || null,
+    rollypaySigningSecret: (map.rollypay_signing_secret ?? "").trim() || null,
+    rollypayTestMode: (map.rollypay_test_mode ?? "false") === "true",
     lavaShopId: (map.lava_shop_id ?? "").trim() || null,
     lavaSecretKey: (map.lava_secret_key ?? "").trim() || null,
     lavaAdditionalKey: (map.lava_additional_key ?? "").trim() || null,
@@ -1004,6 +1008,7 @@ export type PaymentProviderConfig = { id: string; label: string; sortOrder: numb
 const DEFAULT_PAYMENT_PROVIDERS: PaymentProviderConfig[] = [
   { id: "cryptopay", label: "Crypto Bot", sortOrder: 0 },
   { id: "heleket", label: "Heleket", sortOrder: 1 },
+  { id: "rollypay", label: "RollyPay", sortOrder: 1 },
   { id: "yookassa", label: "ЮKassa (СБП / Карты)", sortOrder: 2 },
   { id: "yoomoney", label: "ЮMoney (Карты)", sortOrder: 3 },
   { id: "lava", label: "LAVA (СБП / Карты / СберPay)", sortOrder: 4 },
@@ -1292,6 +1297,9 @@ export async function getPublicConfig(_forCloneBot?: { markupPercent?: number | 
     yookassaRecurringEnabled: full.yookassaRecurringEnabled ?? false,
     cryptopayEnabled: Boolean((full as { cryptopayApiToken?: string | null }).cryptopayApiToken?.trim()),
     heleketEnabled: Boolean((full as { heleketMerchantId?: string | null }).heleketMerchantId?.trim() && (full as { heleketApiKey?: string | null }).heleketApiKey?.trim()),
+    // RollyPay считаем настроенным, когда есть и ключ кассы, и секрет подписи:
+    // без секрета вебхук всё равно будет отвергнут, кнопка была бы обманом.
+    rollypayEnabled: Boolean((full as { rollypayApiKey?: string | null }).rollypayApiKey?.trim() && (full as { rollypaySigningSecret?: string | null }).rollypaySigningSecret?.trim()),
     lavaEnabled: Boolean((full as { lavaShopId?: string | null }).lavaShopId?.trim() && (full as { lavaSecretKey?: string | null }).lavaSecretKey?.trim()),
     lavatopEnabled: Boolean((full as { lavatopApiKey?: string | null }).lavatopApiKey?.trim()),
     overpayEnabled: Boolean(

--- a/backend/src/modules/rollypay/rollypay.service.ts
+++ b/backend/src/modules/rollypay/rollypay.service.ts
@@ -1,0 +1,161 @@
+/**
+ * RollyPay — приём рублёвых платежей (СБП, карты, крипта) с конвертацией в USDT.
+ *
+ * Документация: https://docs.rollypay.io
+ *   • создание платежа — POST {base}/api/v1/payments
+ *   • статус         — GET  {base}/api/v1/payments/{paymentID}
+ *   • аутентификация — заголовки X-API-Key (ключ кассы) и X-Nonce (уникальный
+ *     на запрос; повтор в течение 10 минут → 401 «nonce already used»)
+ *   • вебхуки        — подпись HMAC-SHA256 по строке `timestamp + "." + rawBody`,
+ *     приходит в X-Signature, время — в X-Timestamp
+ *
+ * Подписи самих запросов у RollyPay нет — signing_secret нужен только для
+ * проверки вебхуков.
+ */
+
+import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
+
+const API_BASE = "https://rollypay.io";
+const REQUEST_TIMEOUT_MS = 15_000;
+/** Насколько старым может быть X-Timestamp вебхука (защита от переигрывания). */
+const WEBHOOK_MAX_AGE_SEC = 15 * 60;
+
+export type RollypayConfig = {
+  apiKey: string;
+  signingSecret: string;
+  /** true — платежи создаются в песочнице (поле `test` в запросе) */
+  testMode?: boolean;
+};
+
+export function isRollypayConfigured(config: RollypayConfig | null): boolean {
+  return Boolean(config?.apiKey?.trim() && config?.signingSecret?.trim());
+}
+
+export type CreateRollypayPaymentParams = {
+  config: RollypayConfig;
+  /** Сумма в фиате строкой, например "1500.00" */
+  amount: string;
+  /** Код валюты платежа, по умолчанию RUB */
+  currency: string;
+  orderId: string;
+  description?: string;
+  customerId?: string;
+  successRedirectUrl?: string;
+  failRedirectUrl?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type CreateRollypayPaymentResult =
+  | { ok: true; url: string; paymentId: string | null }
+  | { ok: false; error: string };
+
+interface RollypayPaymentResponse {
+  payment_id?: string;
+  order_id?: string;
+  status?: string;
+  pay_url?: string;
+  message?: string;
+  error?: string;
+}
+
+/** Ошибку провайдера показываем как есть — админу так понятнее, что не так с кассой. */
+function describeError(status: number, body: RollypayPaymentResponse | null, raw: string): string {
+  const detail = body?.message ?? body?.error ?? raw.slice(0, 200);
+  if (status === 401) return `RollyPay: неверный ключ кассы или повтор nonce (${detail})`;
+  return `RollyPay вернул ${status}: ${detail || "без описания"}`;
+}
+
+export async function createRollypayPayment(
+  params: CreateRollypayPaymentParams,
+): Promise<CreateRollypayPaymentResult> {
+  const { config } = params;
+  if (!isRollypayConfigured(config)) return { ok: false, error: "RollyPay не настроен" };
+
+  // RollyPay принимает сумму строкой с двумя знаками.
+  const amount = Number(params.amount);
+  if (!Number.isFinite(amount) || amount <= 0) return { ok: false, error: "Некорректная сумма платежа" };
+
+  const payload: Record<string, unknown> = {
+    amount: amount.toFixed(2),
+    payment_currency: (params.currency || "RUB").toUpperCase(),
+    order_id: params.orderId,
+    ...(params.description ? { description: params.description } : {}),
+    ...(params.customerId ? { customer_id: params.customerId } : {}),
+    ...(params.successRedirectUrl ? { success_redirect_url: params.successRedirectUrl } : {}),
+    ...(params.failRedirectUrl ? { fail_redirect_url: params.failRedirectUrl } : {}),
+    ...(params.metadata ? { metadata: params.metadata } : {}),
+    ...(config.testMode ? { test: true } : {}),
+  };
+
+  // Способ оплаты (sbp/card/crypto) намеренно не задаём — клиент выбирает его
+  // на странице RollyPay, у нас в интерфейсе одна кнопка.
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${API_BASE}/api/v1/payments`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": config.apiKey.trim(),
+        "X-Nonce": randomUUID(),
+      },
+      body: JSON.stringify(payload),
+      signal: ctrl.signal,
+    });
+
+    const raw = await res.text();
+    let body: RollypayPaymentResponse | null = null;
+    try {
+      body = raw ? (JSON.parse(raw) as RollypayPaymentResponse) : null;
+    } catch {
+      /* не-JSON ответ обработаем ниже как ошибку */
+    }
+
+    if (!res.ok) return { ok: false, error: describeError(res.status, body, raw) };
+
+    const url = body?.pay_url?.trim();
+    if (!url) return { ok: false, error: "RollyPay не вернул ссылку на оплату" };
+
+    return { ok: true, url, paymentId: body?.payment_id ?? null };
+  } catch (e) {
+    if (e instanceof Error && e.name === "AbortError") {
+      return { ok: false, error: "RollyPay не ответил вовремя" };
+    }
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Проверка подписи вебхука.
+ *
+ * Подписывается СЫРОЕ тело: `timestamp + "." + rawBody`. Разбирать и снова
+ * сериализовать JSON нельзя — порядок ключей и пробелы изменятся, и подпись
+ * перестанет сходиться.
+ */
+export function verifyRollypayWebhookSignature(
+  signingSecret: string,
+  rawBody: string,
+  timestamp: string | undefined,
+  signature: string | undefined,
+): boolean {
+  const secret = signingSecret?.trim();
+  const ts = timestamp?.trim();
+  const sig = signature?.trim();
+  if (!secret || !ts || !sig) return false;
+
+  // Слишком старый вебхук не принимаем: иначе перехваченный запрос можно
+  // переиграть в любой момент.
+  const tsNum = Number(ts);
+  if (!Number.isFinite(tsNum)) return false;
+  const ageSec = Math.abs(Date.now() / 1000 - tsNum);
+  if (ageSec > WEBHOOK_MAX_AGE_SEC) return false;
+
+  const expected = createHmac("sha256", secret).update(`${ts}.${rawBody}`).digest("hex");
+  const a = Buffer.from(expected, "utf8");
+  const b = Buffer.from(sig.toLowerCase(), "utf8");
+  // timingSafeEqual падает на разной длине — сравниваем её отдельно.
+  return a.length === b.length && timingSafeEqual(a, b);
+}

--- a/backend/src/modules/webhooks/rollypay.webhooks.routes.ts
+++ b/backend/src/modules/webhooks/rollypay.webhooks.routes.ts
@@ -1,0 +1,167 @@
+/**
+ * Webhook RollyPay.
+ *
+ * Приходит на POST /api/webhooks/rollypay с express.raw() — тело нужно сырым:
+ * подпись считается по строке `X-Timestamp + "." + rawBody`, и повторная
+ * сериализация JSON её сломает.
+ *
+ * События: payment.created / paid / canceled / expired / chargeback / refunded.
+ * Зачисляем только `paid` — остальные подтверждаем 200, чтобы RollyPay не
+ * пытался доставить их повторно (до 8 попыток около часа).
+ *
+ * Документация: https://docs.rollypay.io/api/callbacks/
+ */
+
+import { Router, Request, Response } from "express";
+import { prisma } from "../../db.js";
+import { getSystemConfig } from "../client/client.service.js";
+import { verifyRollypayWebhookSignature } from "../rollypay/rollypay.service.js";
+import { activateTariffByPaymentId } from "../tariff/tariff-activation.service.js";
+import { createProxySlotsByPaymentId } from "../proxy/proxy-slots-activation.service.js";
+import { createSingboxSlotsByPaymentId } from "../singbox/singbox-slots-activation.service.js";
+import { applyExtraOptionByPaymentId } from "../extra-options/extra-options.service.js";
+import { distributeReferralRewards } from "../referral/referral.service.js";
+import { notifyBalanceToppedUp, notifyTariffActivated, notifyProxySlotsCreated, notifySingboxSlotsCreated } from "../notification/telegram-notify.service.js";
+import { recordPromoCodeUsageFromPayment } from "../payment/promo-code-usage.util.js";
+import { auditPaymentClientBotAlignment } from "../payment/payment-webhook-audit.util.js";
+
+function hasExtraOptionInMetadata(metadata: string | null): boolean {
+  if (!metadata?.trim()) return false;
+  try {
+    const obj = JSON.parse(metadata) as Record<string, unknown>;
+    return obj?.extraOption != null && typeof obj.extraOption === "object";
+  } catch {
+    return false;
+  }
+}
+
+export const rollypayWebhooksRouter = Router();
+
+type RollypayWebhookPayload = {
+  event_type?: string;
+  payment_id?: string;
+  order_id?: string;
+  status?: string;
+  amount?: string;
+  currency?: string;
+  test?: boolean;
+};
+
+rollypayWebhooksRouter.post("/", async (req: Request, res: Response) => {
+  const rawBody = req.body;
+  const rawString = typeof rawBody === "string" ? rawBody : Buffer.isBuffer(rawBody) ? rawBody.toString("utf8") : "";
+  if (!rawString) {
+    console.warn("[RollyPay Webhook] Empty body");
+    return res.status(200).send("OK");
+  }
+
+  const config = await getSystemConfig();
+  const signingSecret = (config as { rollypaySigningSecret?: string | null }).rollypaySigningSecret?.trim();
+  if (!signingSecret) {
+    // Без секрета подпись проверить нечем. Принять «на веру» нельзя — это дыра:
+    // кто угодно смог бы прислать «оплачено».
+    console.warn("[RollyPay Webhook] Signing secret not configured — REJECTING");
+    return res.status(503).send("Not configured");
+  }
+
+  const signature = req.header("x-signature") ?? undefined;
+  const timestamp = req.header("x-timestamp") ?? undefined;
+  if (!verifyRollypayWebhookSignature(signingSecret, rawString, timestamp, signature)) {
+    console.warn("[RollyPay Webhook] Invalid signature");
+    return res.status(401).send("Invalid signature");
+  }
+
+  let body: RollypayWebhookPayload;
+  try {
+    body = JSON.parse(rawString) as RollypayWebhookPayload;
+  } catch {
+    console.warn("[RollyPay Webhook] Invalid JSON");
+    return res.status(200).send("OK");
+  }
+
+  const status = (body.status ?? "").toLowerCase();
+  const eventType = (body.event_type ?? "").toLowerCase();
+  if (status !== "paid" && eventType !== "payment.paid") {
+    return res.status(200).send("OK");
+  }
+
+  const orderId = body.order_id?.trim();
+  if (!orderId) {
+    console.warn("[RollyPay Webhook] No order_id");
+    return res.status(200).send("OK");
+  }
+
+  const payment = await prisma.payment.findFirst({
+    where: { orderId, provider: "rollypay" },
+    select: {
+      id: true,
+      clientId: true,
+      amount: true,
+      currency: true,
+      tariffId: true,
+      proxyTariffId: true,
+      singboxTariffId: true,
+      status: true,
+      metadata: true,
+    },
+  });
+
+  if (!payment) {
+    console.warn("[RollyPay Webhook] Payment not found", { orderId });
+    return res.status(200).send("OK");
+  }
+
+  await auditPaymentClientBotAlignment(payment);
+
+  if (payment.status === "PAID") {
+    return res.status(200).send("OK");
+  }
+
+  await prisma.payment.update({
+    where: { id: payment.id },
+    data: { status: "PAID", paidAt: new Date(), externalId: body.payment_id ?? null },
+  });
+  await recordPromoCodeUsageFromPayment(payment.id);
+
+  const isExtraOption = hasExtraOptionInMetadata(payment.metadata);
+  const isTopUp = !payment.tariffId && !payment.proxyTariffId && !payment.singboxTariffId && !isExtraOption;
+
+  if (isTopUp) {
+    await prisma.client.update({
+      where: { id: payment.clientId },
+      data: { balance: { increment: payment.amount } },
+    });
+    await notifyBalanceToppedUp(payment.clientId, payment.amount, payment.currency || "RUB", "RollyPay").catch(() => {});
+  } else if (isExtraOption) {
+    const r = await applyExtraOptionByPaymentId(payment.id);
+    if (r.ok) {
+      const { notifyExtraOptionApplied } = await import("../notification/telegram-notify.service.js");
+      await notifyExtraOptionApplied(payment.clientId, payment.id).catch(() => {});
+    }
+  } else if (payment.proxyTariffId) {
+    const proxyResult = await createProxySlotsByPaymentId(payment.id);
+    if (proxyResult.ok) {
+      const tariff = await prisma.proxyTariff.findUnique({ where: { id: payment.proxyTariffId }, select: { name: true } });
+      await notifyProxySlotsCreated(payment.clientId, proxyResult.slotIds, tariff?.name ?? undefined).catch(() => {});
+    }
+  } else if (payment.singboxTariffId) {
+    const singboxResult = await createSingboxSlotsByPaymentId(payment.id);
+    if (singboxResult.ok) {
+      const tariff = await prisma.singboxTariff.findUnique({ where: { id: payment.singboxTariffId }, select: { name: true } });
+      await notifySingboxSlotsCreated(payment.clientId, singboxResult.slotIds, tariff?.name ?? undefined).catch(() => {});
+    }
+  } else {
+    const activation = await activateTariffByPaymentId(payment.id);
+    if (activation.ok) await notifyTariffActivated(payment.clientId, payment.id).catch(() => {});
+  }
+
+  // сжигаем одноразовую персональную скидку после продуктовой покупки.
+  if (!isTopUp) {
+    const { extinguishOneTimeDiscount } = await import("../client/personal-discount.js");
+    await extinguishOneTimeDiscount(payment.clientId).catch(() => {});
+  }
+
+  await distributeReferralRewards(payment.id).catch(() => {});
+
+  return res.status(200).send("OK");
+});

--- a/bot/src/api.ts
+++ b/bot/src/api.ts
@@ -115,6 +115,7 @@ export async function getPublicConfig(): Promise<{
   yookassaEnabled?: boolean;
   cryptopayEnabled?: boolean;
   heleketEnabled?: boolean;
+  rollypayEnabled?: boolean;
   lavaEnabled?: boolean;
   lavatopEnabled?: boolean;
   botWelcomeEnabled?: boolean;
@@ -549,6 +550,14 @@ export async function createHeleketPayment(
   body: { amount?: number; currency?: string; tariffId?: string; tariffPriceOptionId?: string; deviceCount?: number; proxyTariffId?: string; singboxTariffId?: string; promoCode?: string; extraOption?: { kind: "traffic" | "devices" | "servers"; productId: string }; asAdditional?: boolean; extendsSecondarySubId?: string; asGift?: boolean; removeExtrasOnActivate?: boolean; replaceTrialSubId?: string }
 ): Promise<{ paymentId: string; payUrl: string }> {
   return fetchJson("/api/client/heleket/create-payment", { method: "POST", body, token });
+}
+
+/** RollyPay — создать платёж (СБП/карта/крипта), вернуть ссылку на оплату */
+export async function createRollypayPayment(
+  token: string,
+  body: { amount?: number; currency?: string; tariffId?: string; tariffPriceOptionId?: string; deviceCount?: number; proxyTariffId?: string; singboxTariffId?: string; promoCode?: string; extraOption?: { kind: "traffic" | "devices" | "servers"; productId: string }; asAdditional?: boolean; extendsSecondarySubId?: string; asGift?: boolean; removeExtrasOnActivate?: boolean; replaceTrialSubId?: string }
+): Promise<{ paymentId: string; payUrl: string }> {
+  return fetchJson("/api/client/rollypay/create-payment", { method: "POST", body, token });
 }
 
 /** LAVA Business — создать счёт (RUB: СБП / Карты / СберPay) */

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -2398,7 +2398,7 @@ async function showPaymentMethodsForTariff(ctx: any, userId: number, tariff: Tar
   if (trialsCount <= 1) trialReplaceChoice.delete(userId);
   // convNote добавляется СУФФИКСОМ: префикс сместил бы offsets pay.entities (custom emoji).
   const finalText = `${desc && opts.length === 1 ? `${desc}\n\n${pay.text}` : pay.text}${convNote}`;
-  const markup = tariffPaymentMethodButtons(tariff.id, methods, config?.botBackLabel ?? null, innerStyles?.back, innerEmojiIds, balanceLabel, !!config?.yoomoneyEnabled, !!config?.yookassaEnabled, !!config?.cryptopayEnabled, tariff.currency, !!config?.heleketEnabled, !!config?.lavaEnabled, !!config?.lavatopEnabled, config?.botEmojis ?? null);
+  const markup = tariffPaymentMethodButtons(tariff.id, methods, config?.botBackLabel ?? null, innerStyles?.back, innerEmojiIds, balanceLabel, !!config?.yoomoneyEnabled, !!config?.yookassaEnabled, !!config?.cryptopayEnabled, tariff.currency, !!config?.heleketEnabled, !!config?.rollypayEnabled, !!config?.lavaEnabled, !!config?.lavatopEnabled, config?.botEmojis ?? null);
   for (let i = extraRows.length - 1; i >= 0; i--) markup.inline_keyboard.unshift(extraRows[i]!);
   await editMessageContent(ctx, finalText, markup, pay.entities);
 }
@@ -2474,7 +2474,7 @@ async function showGiftPaymentConfirm(ctx: any, userId: number, tariff: TariffIt
     !!config?.yookassaEnabled,
     !!config?.yoomoneyEnabled,
     !!config?.cryptopayEnabled,
-    !!config?.heleketEnabled,
+    !!config?.heleketEnabled, !!config?.rollypayEnabled,
     !!config?.lavaEnabled,
     tariff.currency,
   ));
@@ -4560,6 +4560,80 @@ composer.on("callback_query:data", async (ctx) => {
       }
       return;
     }
+if (data.startsWith("pay_tariff_rollypay:")) {
+      const tariffId = data.slice("pay_tariff_rollypay:".length);
+      const { items } = await api.getPublicTariffs();
+      const tariff = items?.flatMap((c: TariffCategory) => c.tariffs).find((t: TariffItem) => t.id === tariffId);
+      if (!tariff) {
+        await editMessageContent(ctx, "Тариф не найден.", backToMenu(config?.botBackLabel ?? null, innerStyles?.back, innerEmojiIds));
+        return;
+      }
+      try {
+        const discountInfo = activeDiscountCode.get(userId);
+        const promoCode = discountInfo?.code;
+        const sel = selectedTariffOption.get(userId);
+        const opts = sortedPriceOptions(tariff.priceOptions);
+        const eff = sel?.tariffId === tariff.id ? sel.option : (opts.length === 1 ? opts[0]! : null);
+        const unitPrice = eff?.price ?? tariff.price;
+        const effectiveDays = eff?.durationDays ?? tariff.durationDays;
+        const extraDevices = sel?.tariffId === tariff.id ? sel.extraDevices : 0;
+        const { extrasTotal } = applyExtraDevicesPriceBot(tariff.pricePerExtraDevice ?? 0, extraDevices, tariff.deviceDiscountTiers, effectiveDays);
+        const effectivePrice = unitPrice + extrasTotal;
+        // см. yoomoney handler.
+        const asAdditional = addsubPending.get(userId) === tariff.id;
+        const extPairT = extendingSecondaryPending.get(userId);
+        const extendsSecondarySubId = extPairT && extPairT.tariffId === tariff.id ? extPairT.secondaryId : undefined;
+        // юзер выбрал «продлить без устройств».
+        // Флаг прокидываем в backend — там после успешной активации helper удалит устройства.
+        // НЕ удаляем здесь — юзер может закрыть экран оплаты и устройства останутся при нём.
+        const removeExtrasOnActivate = !!(extendsSecondarySubId && pendingDropExtras.get(userId) === extendsSecondarySubId) || (!extendsSecondarySubId && convDropExtras.has(userId));
+        const replaceTrialSubId = !extendsSecondarySubId ? trialReplaceChoice.get(userId) : undefined;
+        let subExtrasForPeriod = 0;
+        if (extendsSecondarySubId && !removeExtrasOnActivate) {
+          try {
+            const allSubs = await api.getAllSubscriptions(token);
+            const target = allSubs.items?.find((it) => it.id === extendsSecondarySubId);
+            const monthly = target?.extraDevicesMonthlyPrice ?? 0;
+            if (monthly > 0 && effectiveDays > 0) {
+              subExtrasForPeriod = Math.round(monthly * (effectiveDays / 30) * 100) / 100;
+            }
+          } catch { /* ignore */ }
+        }
+        const totalPrice = effectivePrice + subExtrasForPeriod;
+        // см. yoomoney handler.
+        const meHeleket = await api.getMe(token);
+        const pdHeleket = meHeleket?.personalDiscountPercent ?? 0;
+        const { discountArg, finalPrice: priceWithDiscountHeleket } = buildTariffDiscountArg(totalPrice, pdHeleket, discountInfo, tariff.currency);
+        const payment = await api.createRollypayPayment(token, {
+          amount: totalPrice,
+          currency: tariff.currency,
+          tariffId: tariff.id,
+          tariffPriceOptionId: eff?.id,
+          deviceCount: extraDevices,
+          promoCode,
+          asAdditional: asAdditional || undefined,
+          extendsSecondarySubId,
+          removeExtrasOnActivate,
+          replaceTrialSubId,
+        });
+        if (promoCode) activeDiscountCode.delete(userId);
+        selectedTariffOption.delete(userId);
+        if (extendsSecondarySubId && removeExtrasOnActivate) extendingSecondaryPending.delete(userId);
+        if (asAdditional) addsubPending.delete(userId);
+        if (removeExtrasOnActivate) pendingDropExtras.delete(userId);
+        convDropExtras.delete(userId);
+        trialReplaceChoice.delete(userId);
+        const nameWithDays = (opts.length > 1 || (sel?.tariffId === tariff.id))
+          ? `${tariff.name} · ${formatRuDays(effectiveDays)}`
+          : tariff.name;
+        const msg = buildPaymentMessage(config, { name: nameWithDays, price: formatMoney(priceWithDiscountHeleket, tariff.currency), amount: String(priceWithDiscountHeleket), currency: tariff.currency, action: "Нажмите кнопку ниже для оплаты:" }, discountArg);
+        await editMessageContent(ctx, msg.text, payUrlMarkup(payment.payUrl, config?.botBackLabel ?? null, innerStyles?.back, innerEmojiIds), msg.entities);
+      } catch (e: unknown) {
+        const m = e instanceof Error ? e.message : "Ошибка создания платежа RollyPay";
+        await editMessageContent(ctx, `❌ ${m}`, backToMenu(config?.botBackLabel ?? null, innerStyles?.back, innerEmojiIds));
+      }
+      return;
+    }
 
     if (data === "menu:extra_options") {
       const options = config?.sellOptions ?? [];
@@ -6266,6 +6340,24 @@ composer.on("callback_query:data", async (ctx) => {
       }
       return;
     }
+if (data.startsWith("topup_rollypay:")) {
+      const amountStr = data.slice("topup_rollypay:".length);
+      const amount = Number(amountStr);
+      if (!Number.isFinite(amount) || amount <= 0) {
+        await editMessageContent(ctx, "Неверная сумма.", backToMenu(config?.botBackLabel ?? null, innerStyles?.back, innerEmojiIds));
+        return;
+      }
+      const client = await api.getMe(token);
+      try {
+        const payment = await api.createRollypayPayment(token, { amount, currency: client.preferredCurrency ?? "RUB" });
+        const rpTopup = titleWithEmoji("CARD", `Пополнение на ${formatMoney(amount, client.preferredCurrency ?? "RUB")}\n\nНажмите кнопку ниже для оплаты:`, config?.botEmojis);
+        await editMessageContent(ctx, rpTopup.text, payUrlMarkup(payment.payUrl, config?.botBackLabel ?? null, innerStyles?.back, innerEmojiIds), rpTopup.entities);
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : "Ошибка создания платежа RollyPay";
+        await editMessageContent(ctx, `❌ ${msg}`, tariffErrMarkup(e, config, innerStyles?.back, innerEmojiIds));
+      }
+      return;
+    }
 
     if (data.startsWith("topup:")) {
       const rest = data.slice("topup:".length);
@@ -6305,6 +6397,7 @@ composer.on("callback_query:data", async (ctx) => {
       const yookassaEnabled = !!config?.yookassaEnabled;
       const cryptopayEnabled = !!config?.cryptopayEnabled;
       const heleketEnabled = !!config?.heleketEnabled;
+      const rollypayEnabled = !!config?.rollypayEnabled;
       const lavaEnabled = !!config?.lavaEnabled;
       const lavatopEnabled = !!config?.lavatopEnabled;
       // Если есть >1 способа любого типа — показываем выбор

--- a/bot/src/keyboard.ts
+++ b/bot/src/keyboard.ts
@@ -637,6 +637,7 @@ export function tariffPaymentMethodButtons(
   cryptopayEnabled?: boolean,
   tariffCurrency?: string,
   heleketEnabled?: boolean,
+  rollypayEnabled?: boolean,
   lavaEnabled?: boolean,
   lavatopEnabled?: boolean,
   // bot_emojis для backButton (text "← Назад" + premium icon).
@@ -673,6 +674,9 @@ export function tariffPaymentMethodButtons(
   }
   if (heleketEnabled) {
     rows.push([btn(providerLabel("heleket", "💳 Heleket — криптовалюта"), `pay_tariff_heleket:${tariffId}`, undefined, cardId)]);
+  }
+  if (rollypayEnabled) {
+    rows.push([btn(providerLabel("rollypay", "💳 RollyPay — СБП, карта, крипта"), `pay_tariff_rollypay:${tariffId}`, undefined, cardId)]);
   }
   for (const m of methods) {
     rows.push([btn(m.label, `pay_tariff:${tariffId}:${m.id}`, undefined, cardId)]);
@@ -907,6 +911,7 @@ export function topupPaymentMethodButtons(
   yookassaEnabled?: boolean,
   cryptopayEnabled?: boolean,
   heleketEnabled?: boolean,
+  rollypayEnabled?: boolean,
   lavaEnabled?: boolean,
   lavatopEnabled?: boolean,
 ): InlineMarkup {
@@ -931,6 +936,9 @@ export function topupPaymentMethodButtons(
   }
   if (heleketEnabled) {
     rows.push([btn(providerLabel("heleket", "💳 Heleket — криптовалюта"), `topup_heleket:${amount}`, "primary", cardId)]);
+  }
+  if (rollypayEnabled) {
+    rows.push([btn(providerLabel("rollypay", "💳 RollyPay — СБП, карта, крипта"), `topup_rollypay:${amount}`, "primary", cardId)]);
   }
   for (const m of methods) {
     rows.push([btn(m.label, `topup:${amount}:${m.id}`, "primary", cardId)]);
@@ -1360,6 +1368,7 @@ export function giftPaymentButtons(
   yoomoneyEnabled?: boolean,
   cryptopayEnabled?: boolean,
   heleketEnabled?: boolean,
+  rollypayEnabled?: boolean,
   lavaEnabled?: boolean,
   tariffCurrency?: string,
 ): InlineMarkup {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2320,6 +2320,32 @@ export const api = {
   ): Promise<{ paymentId: string; payUrl: string }> {
     return request("/client/heleket/create-payment", { method: "POST", body: JSON.stringify(data), token });
   },
+  async rollypayCreatePayment(
+    token: string,
+    data: {
+      amount?: number;
+      currency?: string;
+      tariffId?: string;
+      tariffPriceOptionId?: string;
+      deviceCount?: number;
+      proxyTariffId?: string;
+      singboxTariffId?: string;
+      promoCode?: string;
+      extraOption?: { kind: "traffic" | "devices" | "servers"; productId: string; targetSubscriptionId?: string };
+      customBuild?: { days: number; devices: number; trafficGb?: number };
+      // мульти-подписки как в боте.
+      // extendsSecondarySubId — продлить КОНКРЕТНУЮ подписку; asAdditional — купить НОВУЮ доп.;
+      // asGift — подарочная; removeExtrasOnActivate — сбросить доп. устройства при активации.
+      extendsSecondarySubId?: string;
+      asAdditional?: boolean;
+      asGift?: boolean;
+      removeExtrasOnActivate?: boolean;
+      /** какой триал заменить этой покупкой. */
+      replaceTrialSubId?: string;
+    }
+  ): Promise<{ paymentId: string; payUrl: string }> {
+    return request("/client/rollypay/create-payment", { method: "POST", body: JSON.stringify(data), token });
+  },
 
   /** LAVA Business — создание счёта (RUB: СБП / Карты / СберPay), возвращает ссылку на оплату */
   async lavaCreatePayment(
@@ -3218,6 +3244,9 @@ export type UpdateSettingsPayload = {
   cryptopayTestnet?: boolean;
   heleketMerchantId?: string | null;
   heleketApiKey?: string | null;
+  rollypayApiKey?: string | null;
+  rollypaySigningSecret?: string | null;
+  rollypayTestMode?: boolean;
   lavaShopId?: string | null;
   lavaSecretKey?: string | null;
   lavaAdditionalKey?: string | null;
@@ -3711,6 +3740,9 @@ export interface AdminSettings {
   cryptopayTestnet?: boolean;
   heleketMerchantId?: string | null;
   heleketApiKey?: string | null;
+  rollypayApiKey?: string | null;
+  rollypaySigningSecret?: string | null;
+  rollypayTestMode?: boolean;
   lavaShopId?: string | null;
   lavaSecretKey?: string | null;
   lavaAdditionalKey?: string | null;
@@ -5160,6 +5192,7 @@ export interface PublicConfig {
   yookassaEnabled?: boolean;
   cryptopayEnabled?: boolean;
   heleketEnabled?: boolean;
+  rollypayEnabled?: boolean;
   lavaEnabled?: boolean;
   lavatopEnabled?: boolean;
   overpayEnabled?: boolean;

--- a/frontend/src/pages/cabinet/aurora/aurora-tariffs.tsx
+++ b/frontend/src/pages/cabinet/aurora/aurora-tariffs.tsx
@@ -49,6 +49,7 @@ type PayMethod =
   | { kind: "yoomoney"; label: string; icon: typeof Wallet }
   | { kind: "cryptopay"; label: string; icon: typeof Bitcoin }
   | { kind: "heleket"; label: string; icon: typeof Bitcoin }
+  | { kind: "rollypay"; label: string; icon: typeof Wallet }
   | { kind: "lava"; label: string; icon: typeof Wallet }
   | { kind: "balance"; label: string; icon: typeof Wallet };
 
@@ -249,6 +250,7 @@ export function AuroraTariffs() {
     if (config.yoomoneyEnabled) list.push({ kind: "yoomoney", label: "YooMoney", icon: Wallet });
     if (config.cryptopayEnabled) list.push({ kind: "cryptopay", label: "Crypto Pay", icon: Bitcoin });
     if (config.heleketEnabled) list.push({ kind: "heleket", label: "Heleket", icon: Bitcoin });
+    if ((config as { rollypayEnabled?: boolean }).rollypayEnabled) list.push({ kind: "rollypay", label: "RollyPay", icon: Wallet });
     if (config.lavaEnabled) list.push({ kind: "lava", label: "Lava", icon: Wallet });
     return list;
   }, [config]);
@@ -419,6 +421,9 @@ export function AuroraTariffs() {
         url = r.miniAppPayUrl ?? r.webAppPayUrl ?? r.payUrl;
       } else if (selectedMethod.kind === "heleket") {
         const r = await api.heleketCreatePayment(state.token, base);
+        url = r.payUrl;
+      } else if (selectedMethod.kind === "rollypay") {
+        const r = await api.rollypayCreatePayment(state.token, base);
         url = r.payUrl;
       } else if (selectedMethod.kind === "lava") {
         const r = await api.lavaCreatePayment(state.token, base);

--- a/frontend/src/pages/cabinet/client-extra-options.tsx
+++ b/frontend/src/pages/cabinet/client-extra-options.tsx
@@ -55,6 +55,7 @@ export function ClientExtraOptionsPage() {
   const [yookassaEnabled, setYookassaEnabled] = useState(false);
   const [cryptopayEnabled, setCryptopayEnabled] = useState(false);
   const [heleketEnabled, setHeleketEnabled] = useState(false);
+  const [rollypayEnabled, setRollypayEnabled] = useState(false);
   const [lavaEnabled, setLavaEnabled] = useState(false);
   const [overpayEnabled, setOverpayEnabled] = useState(false);
   const [paymentProviders, setPaymentProviders] = useState<{ id: string; label: string; sortOrder: number }[]>([]);
@@ -81,6 +82,7 @@ export function ClientExtraOptionsPage() {
       setYookassaEnabled(Boolean(c.yookassaEnabled));
       setCryptopayEnabled(Boolean(c.cryptopayEnabled));
       setHeleketEnabled(Boolean(c.heleketEnabled));
+      setRollypayEnabled(Boolean(c.rollypayEnabled));
       setLavaEnabled(Boolean(c.lavaEnabled));
       setOverpayEnabled(Boolean(c.overpayEnabled));
       setPaymentProviders(c.paymentProviders ?? []);
@@ -176,6 +178,22 @@ export function ClientExtraOptionsPage() {
         extraOption: { kind: option.kind, productId: option.id, targetSubscriptionId: selectedSubId ?? undefined },
       });
       if (res.payUrl) setReadyUrl({ url: res.payUrl, provider: "Heleket", paymentId: res.paymentId });
+    } catch (e) {
+      setPayError(e instanceof Error ? e.message : "Ошибка создания платежа");
+    } finally {
+      setPayLoading(false);
+    }
+  }
+
+  async function startRollypayPayment(option: PublicSellOption) {
+    if (!token) return;
+    setPayError(null);
+    setPayLoading(true);
+    try {
+      const res = await api.rollypayCreatePayment(token, {
+        extraOption: { kind: option.kind, productId: option.id, targetSubscriptionId: selectedSubId ?? undefined },
+      });
+      if (res.payUrl) setReadyUrl({ url: res.payUrl, provider: "RollyPay", paymentId: res.paymentId });
     } catch (e) {
       setPayError(e instanceof Error ? e.message : "Ошибка создания платежа");
     } finally {
@@ -426,6 +444,7 @@ export function ClientExtraOptionsPage() {
               const colorMap: Record<string, { bg10: string; bg20: string; text: string }> = {
                 cryptopay: { bg10: "bg-yellow-500/10", bg20: "group-hover:bg-yellow-500/20", text: "text-yellow-500" },
                 heleket: { bg10: "bg-orange-500/10", bg20: "group-hover:bg-orange-500/20", text: "text-orange-500" },
+                rollypay: { bg10: "bg-sky-500/10", bg20: "group-hover:bg-sky-500/20", text: "text-sky-500" },
                 yookassa: { bg10: "bg-green-500/10", bg20: "group-hover:bg-green-500/20", text: "text-green-500" },
                 yoomoney: { bg10: "bg-green-500/10", bg20: "group-hover:bg-green-500/20", text: "text-green-500" },
                 lava: { bg10: "bg-sky-500/10", bg20: "group-hover:bg-sky-500/20", text: "text-sky-500" },
@@ -436,6 +455,7 @@ export function ClientExtraOptionsPage() {
               const providers: ProviderEntry[] = [
                 { id: "cryptopay", enabled: cryptopayEnabled, onClick: () => startCryptopayPayment(payModal!), label: providerLabel("cryptopay", "Crypto Bot"), icon: "crypto" },
                 { id: "heleket", enabled: heleketEnabled, onClick: () => startHeleketPayment(payModal!), label: providerLabel("heleket", "Heleket"), icon: "crypto" },
+                { id: "rollypay", enabled: rollypayEnabled, onClick: () => startRollypayPayment(payModal!), label: providerLabel("rollypay", "RollyPay"), icon: "card" },
                 { id: "yookassa", enabled: yookassaEnabled && payModal?.currency.toUpperCase() === "RUB", onClick: () => startYookassaPayment(payModal!), label: providerLabel("yookassa", "СБП / Карты РФ"), icon: "card" },
                 { id: "yoomoney", enabled: yoomoneyEnabled && payModal?.currency.toUpperCase() === "RUB", onClick: () => startYoomoneyPayment(payModal!), label: providerLabel("yoomoney", "ЮMoney / Карты"), icon: "card" },
                 { id: "lava", enabled: lavaEnabled && payModal?.currency.toUpperCase() === "RUB", onClick: () => startLavaPayment(payModal!), label: providerLabel("lava", "LAVA"), icon: "card" },

--- a/frontend/src/pages/cabinet/client-proxy.tsx
+++ b/frontend/src/pages/cabinet/client-proxy.tsx
@@ -79,6 +79,7 @@ export function ClientProxyPage() {
   const [yookassaEnabled, setYookassaEnabled] = useState(false);
   const [cryptopayEnabled, setCryptopayEnabled] = useState(false);
   const [heleketEnabled, setHeleketEnabled] = useState(false);
+  const [rollypayEnabled, setRollypayEnabled] = useState(false);
   const [lavaEnabled, setLavaEnabled] = useState(false);
   const [overpayEnabled, setOverpayEnabled] = useState(false);
   const [paymentProviders, setPaymentProviders] = useState<{ id: string; label: string; sortOrder: number }[]>([]);
@@ -106,6 +107,7 @@ export function ClientProxyPage() {
       setYookassaEnabled(Boolean(c.yookassaEnabled));
       setCryptopayEnabled(Boolean(c.cryptopayEnabled));
       setHeleketEnabled(Boolean(c.heleketEnabled));
+      setRollypayEnabled(Boolean(c.rollypayEnabled));
       setLavaEnabled(Boolean(c.lavaEnabled));
       setOverpayEnabled(Boolean(c.overpayEnabled));
       setPaymentProviders(c.paymentProviders ?? []);
@@ -219,6 +221,24 @@ export function ClientProxyPage() {
         proxyTariffId: tariff.id,
       });
       if (res.payUrl) setReadyUrl({ url: res.payUrl, provider: "Heleket" });
+    } catch (e) {
+      setPayError(e instanceof Error ? e.message : "Ошибка");
+    } finally {
+      setPayLoading(false);
+    }
+  }
+
+  async function startRollypayPayment(tariff: ProxyTariff) {
+    if (!token) return;
+    setPayError(null);
+    setPayLoading(true);
+    try {
+      const res = await api.rollypayCreatePayment(token, {
+        amount: tariff.price,
+        currency: tariff.currency,
+        proxyTariffId: tariff.id,
+      });
+      if (res.payUrl) setReadyUrl({ url: res.payUrl, provider: "RollyPay" });
     } catch (e) {
       setPayError(e instanceof Error ? e.message : "Ошибка");
     } finally {
@@ -396,6 +416,7 @@ export function ClientProxyPage() {
               const colorMap: Record<string, { bg10: string; bg20: string; text: string }> = {
                 cryptopay: { bg10: "bg-yellow-500/10", bg20: "group-hover:bg-yellow-500/20", text: "text-yellow-500" },
                 heleket: { bg10: "bg-orange-500/10", bg20: "group-hover:bg-orange-500/20", text: "text-orange-500" },
+                rollypay: { bg10: "bg-sky-500/10", bg20: "group-hover:bg-sky-500/20", text: "text-sky-500" },
                 yookassa: { bg10: "bg-green-500/10", bg20: "group-hover:bg-green-500/20", text: "text-green-500" },
                 yoomoney: { bg10: "bg-green-500/10", bg20: "group-hover:bg-green-500/20", text: "text-green-500" },
                 lava: { bg10: "bg-sky-500/10", bg20: "group-hover:bg-sky-500/20", text: "text-sky-500" },
@@ -406,6 +427,7 @@ export function ClientProxyPage() {
               const providers: ProviderEntry[] = [
                 { id: "cryptopay", enabled: cryptopayEnabled, onClick: () => startCryptopayPayment(payModal), label: providerLabel("cryptopay", "Crypto Bot"), icon: "crypto" },
                 { id: "heleket", enabled: heleketEnabled, onClick: () => startHeleketPayment(payModal), label: providerLabel("heleket", "Heleket"), icon: "crypto" },
+                { id: "rollypay", enabled: rollypayEnabled, onClick: () => startRollypayPayment(payModal), label: providerLabel("rollypay", "RollyPay"), icon: "card" },
                 { id: "yookassa", enabled: yookassaEnabled && payModal.currency.toUpperCase() === "RUB", onClick: () => startYookassaPayment(payModal), label: providerLabel("yookassa", "СБП / Карты РФ"), icon: "card" },
                 { id: "yoomoney", enabled: yoomoneyEnabled && payModal.currency.toUpperCase() === "RUB", onClick: () => startYoomoneyPayment(payModal), label: providerLabel("yoomoney", "ЮMoney / Карты"), icon: "card" },
                 { id: "lava", enabled: lavaEnabled && payModal.currency.toUpperCase() === "RUB", onClick: () => startLavaPayment(payModal), label: providerLabel("lava", "LAVA"), icon: "card" },

--- a/frontend/src/pages/cabinet/client-singbox.tsx
+++ b/frontend/src/pages/cabinet/client-singbox.tsx
@@ -75,6 +75,7 @@ export function ClientSingboxPage() {
   const [yookassaEnabled, setYookassaEnabled] = useState(false);
   const [cryptopayEnabled, setCryptopayEnabled] = useState(false);
   const [heleketEnabled, setHeleketEnabled] = useState(false);
+  const [rollypayEnabled, setRollypayEnabled] = useState(false);
   const [lavaEnabled, setLavaEnabled] = useState(false);
   const [overpayEnabled, setOverpayEnabled] = useState(false);
   const [paymentProviders, setPaymentProviders] = useState<{ id: string; label: string; sortOrder: number }[]>([]);
@@ -102,6 +103,7 @@ export function ClientSingboxPage() {
       setYookassaEnabled(Boolean(c.yookassaEnabled));
       setCryptopayEnabled(Boolean(c.cryptopayEnabled));
       setHeleketEnabled(Boolean(c.heleketEnabled));
+      setRollypayEnabled(Boolean(c.rollypayEnabled));
       setLavaEnabled(Boolean(c.lavaEnabled));
       setOverpayEnabled(Boolean(c.overpayEnabled));
       setPaymentProviders(c.paymentProviders ?? []);
@@ -215,6 +217,24 @@ export function ClientSingboxPage() {
         singboxTariffId: tariff.id,
       });
       if (res.payUrl) setReadyUrl({ url: res.payUrl, provider: "Heleket" });
+    } catch (e) {
+      setPayError(e instanceof Error ? e.message : "Ошибка");
+    } finally {
+      setPayLoading(false);
+    }
+  }
+
+  async function startRollypayPayment(tariff: SingboxTariff) {
+    if (!token) return;
+    setPayError(null);
+    setPayLoading(true);
+    try {
+      const res = await api.rollypayCreatePayment(token, {
+        amount: tariff.price,
+        currency: tariff.currency,
+        singboxTariffId: tariff.id,
+      });
+      if (res.payUrl) setReadyUrl({ url: res.payUrl, provider: "RollyPay" });
     } catch (e) {
       setPayError(e instanceof Error ? e.message : "Ошибка");
     } finally {
@@ -392,6 +412,7 @@ export function ClientSingboxPage() {
               const colorMap: Record<string, { bg10: string; bg20: string; text: string }> = {
                 cryptopay: { bg10: "bg-yellow-500/10", bg20: "group-hover:bg-yellow-500/20", text: "text-yellow-500" },
                 heleket: { bg10: "bg-orange-500/10", bg20: "group-hover:bg-orange-500/20", text: "text-orange-500" },
+                rollypay: { bg10: "bg-sky-500/10", bg20: "group-hover:bg-sky-500/20", text: "text-sky-500" },
                 yookassa: { bg10: "bg-green-500/10", bg20: "group-hover:bg-green-500/20", text: "text-green-500" },
                 yoomoney: { bg10: "bg-green-500/10", bg20: "group-hover:bg-green-500/20", text: "text-green-500" },
                 lava: { bg10: "bg-sky-500/10", bg20: "group-hover:bg-sky-500/20", text: "text-sky-500" },
@@ -402,6 +423,7 @@ export function ClientSingboxPage() {
               const providers: ProviderEntry[] = [
                 { id: "cryptopay", enabled: cryptopayEnabled, onClick: () => startCryptopayPayment(payModal), label: providerLabel("cryptopay", "Crypto Bot"), icon: "crypto" },
                 { id: "heleket", enabled: heleketEnabled, onClick: () => startHeleketPayment(payModal), label: providerLabel("heleket", "Heleket"), icon: "crypto" },
+                { id: "rollypay", enabled: rollypayEnabled, onClick: () => startRollypayPayment(payModal), label: providerLabel("rollypay", "RollyPay"), icon: "card" },
                 { id: "yookassa", enabled: yookassaEnabled && payModal.currency.toUpperCase() === "RUB", onClick: () => startYookassaPayment(payModal), label: providerLabel("yookassa", "СБП / Карты РФ"), icon: "card" },
                 { id: "yoomoney", enabled: yoomoneyEnabled && payModal.currency.toUpperCase() === "RUB", onClick: () => startYoomoneyPayment(payModal), label: providerLabel("yoomoney", "ЮMoney / Карты"), icon: "card" },
                 { id: "lava", enabled: lavaEnabled && payModal.currency.toUpperCase() === "RUB", onClick: () => startLavaPayment(payModal), label: providerLabel("lava", "LAVA"), icon: "card" },

--- a/frontend/src/pages/cabinet/client-tariffs.tsx
+++ b/frontend/src/pages/cabinet/client-tariffs.tsx
@@ -113,6 +113,7 @@ function ClassicTariffsPage() {
   const [yookassaEnabled, setYookassaEnabled] = useState(false);
   const [cryptopayEnabled, setCryptopayEnabled] = useState(false);
   const [heleketEnabled, setHeleketEnabled] = useState(false);
+  const [rollypayEnabled, setRollypayEnabled] = useState(false);
   const [lavaEnabled, setLavaEnabled] = useState(false);
   const [lavatopEnabled, setLavatopEnabled] = useState(false);
   const [overpayEnabled, setOverpayEnabled] = useState(false);
@@ -267,6 +268,7 @@ function ClassicTariffsPage() {
       setYookassaEnabled(Boolean(c.yookassaEnabled));
       setCryptopayEnabled(Boolean(c.cryptopayEnabled));
       setHeleketEnabled(Boolean(c.heleketEnabled));
+      setRollypayEnabled(Boolean(c.rollypayEnabled));
       setLavaEnabled(Boolean(c.lavaEnabled));
       setLavatopEnabled(Boolean(c.lavatopEnabled));
       setOverpayEnabled(Boolean(c.overpayEnabled));
@@ -589,6 +591,28 @@ function ClassicTariffsPage() {
         ...purchaseExtra(),
       });
       if (res.payUrl) setReadyUrl({ url: res.payUrl, provider: "Heleket", paymentId: res.paymentId });
+    } catch (e) {
+      setPayError(e instanceof Error ? e.message : t("cabinet.tariffs.error_payment"));
+    } finally {
+      setPayLoading(false);
+    }
+  }
+
+  async function startRollypayPayment(tariff: TariffForPay) {
+    if (!token) return;
+    setPayError(null);
+    setPayLoading(true);
+    try {
+      const res = await api.rollypayCreatePayment(token, {
+        amount: tariff.price,
+        currency: tariff.currency,
+        tariffId: tariff.id,
+        tariffPriceOptionId: selectedPriceOptionId ?? undefined,
+        deviceCount: selectedExtraDevices,
+        promoCode: promoResult ? promoInput.trim() : undefined,
+        ...purchaseExtra(),
+      });
+      if (res.payUrl) setReadyUrl({ url: res.payUrl, provider: "RollyPay", paymentId: res.paymentId });
     } catch (e) {
       setPayError(e instanceof Error ? e.message : t("cabinet.tariffs.error_payment"));
     } finally {
@@ -1148,6 +1172,7 @@ function ClassicTariffsPage() {
               const colorMap: Record<string, { bg10: string; bg20: string; text: string }> = {
                 cryptopay: { bg10: "bg-yellow-500/10", bg20: "group-hover:bg-yellow-500/20", text: "text-yellow-500" },
                 heleket: { bg10: "bg-orange-500/10", bg20: "group-hover:bg-orange-500/20", text: "text-orange-500" },
+                rollypay: { bg10: "bg-sky-500/10", bg20: "group-hover:bg-sky-500/20", text: "text-sky-500" },
                 yookassa: { bg10: "bg-green-500/10", bg20: "group-hover:bg-green-500/20", text: "text-green-500" },
                 yoomoney: { bg10: "bg-green-500/10", bg20: "group-hover:bg-green-500/20", text: "text-green-500" },
                 lava: { bg10: "bg-sky-500/10", bg20: "group-hover:bg-sky-500/20", text: "text-sky-500" },
@@ -1158,6 +1183,7 @@ function ClassicTariffsPage() {
               const providers: ProviderEntry[] = [
                 { id: "cryptopay", enabled: cryptopayEnabled, onClick: () => startCryptopayPayment(tariff), label: providerLabel("cryptopay", "Crypto Bot"), icon: "crypto" },
                 { id: "heleket", enabled: heleketEnabled, onClick: () => startHeleketPayment(tariff), label: providerLabel("heleket", "Heleket"), icon: "crypto" },
+                { id: "rollypay", enabled: rollypayEnabled, onClick: () => startRollypayPayment(tariff), label: providerLabel("rollypay", "RollyPay"), icon: "card" },
                 { id: "yookassa", enabled: yookassaEnabled && isRub, onClick: () => startYookassaPayment(tariff), label: providerLabel("yookassa", t("cabinet.tariffs.sbp_cards_ru")), icon: "card" },
                 { id: "yoomoney", enabled: yoomoneyEnabled && isRub, onClick: () => startYoomoneyPayment(tariff), label: providerLabel("yoomoney", t("cabinet.tariffs.yoomoney_cards")), icon: "card" },
                 { id: "lava", enabled: lavaEnabled && isRub, onClick: () => startLavaPayment(tariff), label: providerLabel("lava", "LAVA"), icon: "card" },

--- a/frontend/src/pages/cabinet/stealth/stealth-tariffs.tsx
+++ b/frontend/src/pages/cabinet/stealth/stealth-tariffs.tsx
@@ -55,6 +55,7 @@ type PayMethod =
   | { kind: "yoomoney"; label: string; icon: typeof Wallet }
   | { kind: "cryptopay"; label: string; icon: typeof Bitcoin }
   | { kind: "heleket"; label: string; icon: typeof Bitcoin }
+  | { kind: "rollypay"; label: string; icon: typeof Wallet }
   | { kind: "lava"; label: string; icon: typeof Wallet }
   | { kind: "balance"; label: string; icon: typeof Wallet };
 
@@ -244,6 +245,7 @@ export function StealthTariffs() {
     if (config.yoomoneyEnabled) list.push({ kind: "yoomoney", label: "YooMoney", icon: Wallet });
     if (config.cryptopayEnabled) list.push({ kind: "cryptopay", label: "Crypto Pay", icon: Bitcoin });
     if (config.heleketEnabled) list.push({ kind: "heleket", label: "Heleket", icon: Bitcoin });
+    if ((config as { rollypayEnabled?: boolean }).rollypayEnabled) list.push({ kind: "rollypay", label: "RollyPay", icon: Wallet });
     if (config.lavaEnabled) list.push({ kind: "lava", label: "Lava", icon: Wallet });
     return list;
   }, [config]);
@@ -395,6 +397,9 @@ export function StealthTariffs() {
         url = r.miniAppPayUrl ?? r.webAppPayUrl ?? r.payUrl;
       } else if (selectedMethod.kind === "heleket") {
         const r = await api.heleketCreatePayment(state.token, base);
+        url = r.payUrl;
+      } else if (selectedMethod.kind === "rollypay") {
+        const r = await api.rollypayCreatePayment(state.token, base);
         url = r.payUrl;
       } else if (selectedMethod.kind === "lava") {
         const r = await api.lavaCreatePayment(state.token, base);

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -839,6 +839,9 @@ export function SettingsPage() {
         cryptopayTestnet: settings.cryptopayTestnet ?? false,
         heleketMerchantId: settings.heleketMerchantId ?? null,
         heleketApiKey: settings.heleketApiKey && settings.heleketApiKey !== "********" ? settings.heleketApiKey : undefined,
+        rollypayApiKey: settings.rollypayApiKey && settings.rollypayApiKey !== "********" ? settings.rollypayApiKey : undefined,
+        rollypaySigningSecret: settings.rollypaySigningSecret && settings.rollypaySigningSecret !== "********" ? settings.rollypaySigningSecret : undefined,
+        rollypayTestMode: settings.rollypayTestMode === true,
         lavaShopId: settings.lavaShopId ?? null,
         lavaSecretKey: settings.lavaSecretKey && settings.lavaSecretKey !== "********" ? settings.lavaSecretKey : undefined,
         lavaAdditionalKey: settings.lavaAdditionalKey && settings.lavaAdditionalKey !== "********" ? settings.lavaAdditionalKey : undefined,
@@ -3459,6 +3462,86 @@ export function SettingsPage() {
                         />
                         <p className="text-xs text-muted-foreground">{t("admin.settings.heleket_key_hint")}</p>
                       </div>
+                    </div>
+                    <div className="pt-2 border-t">
+                      <Button type="submit" disabled={saving} className="min-w-[140px]">
+                        {saving ? t("admin.settings.saving") : t("admin.settings.save")}
+                      </Button>
+                    </div>
+                  </CardContent>
+                </CollapsibleContent>
+              </Collapsible>
+              {/* RollyPay — приём рублей (СБП/карты/крипта) с конвертацией в USDT.
+                  Кнопка у клиента появляется только когда заполнены ОБА поля: без секрета
+                  подписи вебхук всё равно будет отвергнут. */}
+              <Collapsible defaultOpen={false} className="group mt-4">
+                <CollapsibleTrigger asChild>
+                  <button
+                    type="button"
+                    className="w-full cursor-pointer rounded-t-lg text-left transition-colors hover:bg-muted/50 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                  >
+                    <CardHeader className="pointer-events-none [&_.chevron]:transition-transform [&_.chevron]:duration-200 group-data-[state=open]:[&_.chevron]:rotate-180">
+                      <div className="flex items-center justify-between pr-2">
+                        <div className="flex items-center gap-2">
+                          <Wallet className="h-5 w-5 text-primary" />
+                          <CardTitle>RollyPay</CardTitle>
+                          <span className="text-xs font-normal text-muted-foreground">СБП, карты, криптовалюта</span>
+                        </div>
+                        <ChevronDown className="chevron h-5 w-5 shrink-0 text-muted-foreground" />
+                      </div>
+                    </CardHeader>
+                  </button>
+                </CollapsibleTrigger>
+                <CollapsibleContent>
+                  <CardContent className="space-y-4">
+                    <p className="text-sm text-muted-foreground">
+                      Приём рублёвых платежей с автоматической конвертацией в USDT. Ключи выдаются при
+                      создании кассы в личном кабинете RollyPay. Способ оплаты (СБП, карта, криптовалюта)
+                      клиент выбирает уже на странице RollyPay — у нас одна кнопка.
+                    </p>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                      <div className="space-y-2">
+                        <Label>API-ключ кассы</Label>
+                        <Input
+                          type="password"
+                          value={settings.rollypayApiKey ?? ""}
+                          onChange={(e) => setSettings((s) => (s ? { ...s, rollypayApiKey: e.target.value || null } : s))}
+                          placeholder="rpk_live_…"
+                        />
+                        <p className="text-xs text-muted-foreground">Уходит в заголовке X-API-Key.</p>
+                      </div>
+                      <div className="space-y-2">
+                        <Label>Секрет подписи</Label>
+                        <Input
+                          type="password"
+                          value={settings.rollypaySigningSecret ?? ""}
+                          onChange={(e) => setSettings((s) => (s ? { ...s, rollypaySigningSecret: e.target.value || null } : s))}
+                          placeholder="whsec_…"
+                        />
+                        <p className="text-xs text-muted-foreground">
+                          Проверка подписи вебхуков. Без него уведомления об оплате отвергаются — платежи не зачтутся.
+                        </p>
+                      </div>
+                    </div>
+                    <label className="flex items-center gap-3 p-3.5 rounded-xl bg-card/40 border border-border cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={settings.rollypayTestMode === true}
+                        onChange={(e) => setSettings((s) => (s ? { ...s, rollypayTestMode: e.target.checked } : s))}
+                        className="rounded border w-4 h-4"
+                      />
+                      <div className="flex-1">
+                        <span className="text-sm font-medium">Тестовый режим (sandbox)</span>
+                        <p className="text-[11px] text-muted-foreground mt-0.5">
+                          Платежи создаются с флагом test — реальные деньги не списываются.
+                        </p>
+                      </div>
+                    </label>
+                    <div className="rounded-xl bg-muted/40 border border-border p-3.5">
+                      <p className="text-xs text-muted-foreground">
+                        Адрес для вебхука задаётся в личном кабинете RollyPay — в запросе его передать нельзя:
+                      </p>
+                      <code className="text-xs break-all">{`${window.location.origin}/api/webhooks/rollypay`}</code>
                     </div>
                     <div className="pt-2 border-t">
                       <Button type="submit" disabled={saving} className="min-w-[140px]">


### PR DESCRIPTION
Новый платёжный провайдер: приём рублей (СБП, карты, криптовалюта) с автоматической конвертацией в USDT. Документация: https://docs.rollypay.io

## Бэкенд

`modules/rollypay/rollypay.service.ts` — создание платежа `POST /api/v1/payments` с заголовками `X-API-Key` и **уникальным `X-Nonce` на каждый запрос** (повтор в течение 10 минут даёт 401), таймаут 15 секунд.

`modules/webhooks/rollypay.webhooks.routes.ts` — подпись HMAC-SHA256 по строке `timestamp + "." + СЫРОЕ тело`. Тело берётся через `express.raw()`: если распарсить и снова сериализовать JSON, порядок ключей и пробелы изменятся и подпись перестанет сходиться. Дополнительно отбраковываются просроченные метки времени — иначе перехваченный запрос можно переиграть в любой момент. Зачисляем только статус `paid`, остальные события подтверждаем `200`, чтобы RollyPay не долбился повторами.

Плюс `POST /client/rollypay/create-payment`, ключи в настройках и флаг в публичном конфиге.

## Интерфейс

Карточка настроек: ключ кассы, секрет подписи, тумблер песочницы и подсказка с адресом вебхука. Кнопка оплаты — в тарифах, доп. опциях, прокси, sing-box, обоих мини-аппах (Aurora и Stealth) и в боте: покупка тарифа и пополнение баланса.

## Два решения, о которых стоит знать

**Способ оплаты не передаём.** RollyPay умеет `sbp`, `card`, `intl_card`, `crypto`, но выбор оставлен на их странице — у нас одна кнопка. Так меньше мест для ошибки и не нужно решать за владельца, какие способы включены.

**Провайдер включается только когда заданы ОБА ключа.** Без секрета подписи вебхук всё равно будет отвергнут, и кнопка обманывала бы клиента: деньги ушли, а подписка не активировалась. Без настроенного секрета вебхук отвечает `503`, а не пропускает платёж «на веру».

Адрес вебхука задаётся в личном кабинете RollyPay — в запросе такого поля нет:

```
https://{ваш-домен}/api/webhooks/rollypay
```

## Проверено на живой кассе

| шаг | результат |
|---|---|
| создание платежа через наш эндпоинт | `PENDING / rollypay`, ссылка получена |
| подписанный вебхук `payment.paid` | `200` |
| платёж после вебхука | `PAID`, проставлен `paid_at` |
| баланс клиента | пополнен |
| неверная подпись | `401` |
| просроченная метка времени | `401` |
| подменённое тело с валидной подписью | `401` |

## Что не покрыто

Пополнение баланса в профиле, дашборд, гибкий тариф и диалог продления — там разметка оплаты отличается от остальных экранов, механический перенос не подошёл. Сделаю отдельным PR.
