### PR TITLE
fix(yookassa): оплаты не зачислялись, если Basic Auth не настроен

### DIFF
--- a/backend/src/modules/webhooks/yookassa.webhooks.routes.ts
+++ b/backend/src/modules/webhooks/yookassa.webhooks.routes.ts
@@ -13,6 +13,7 @@
  */
 
 import { Router } from "express";
+import { getYookassaPaymentStatus } from "../yookassa/yookassa.service.js";
 import { timingSafeEqual } from "node:crypto";
 import { prisma } from "../../db.js";
 import { getSystemConfig } from "../client/client.service.js";
@@ -115,7 +116,12 @@ async function verifyYookassaWebhookAuth(req: { headers: Record<string, unknown>
 yookassaWebhooksRouter.post("/yookassa", async (req, res) => {
   // ВАЖНО: проверка аутентификации ПЕРЕД любыми DB-операциями.
   const auth = await verifyYookassaWebhookAuth(req);
-  if (!auth.ok) {
+  // Basic Auth у ЮKassa опционален. Если он не настроен — не отвергаем
+  // уведомление (иначе оплаты просто не зачисляются), а проверяем платёж
+  // запросом к самой кассе ниже. Все остальные провалы аутентификации —
+  // это подделка или неверные реквизиты, их отклоняем как прежде.
+  const needsApiConfirmation = !auth.ok && auth.reason === "no_credentials_configured";
+  if (!auth.ok && !needsApiConfirmation) {
     console.warn(`[YooKassa Webhook] Auth failed: ${auth.reason}`);
     res.set("WWW-Authenticate", 'Basic realm="yookassa-webhook"');
     return res.status(401).json({ message: "Unauthorized" });
@@ -142,6 +148,24 @@ yookassaWebhooksRouter.post("/yookassa", async (req, res) => {
   if (event !== "payment.succeeded") {
     console.log("[YooKassa Webhook] Ignored event", { event, paymentId });
     return res.status(200).send("OK");
+  }
+
+  // Без Basic Auth телу верить нельзя — спрашиваем статус у самой ЮKassa.
+  if (needsApiConfirmation) {
+    const cfg = await getSystemConfig();
+    const shopId = (cfg as { yookassaShopId?: string | null }).yookassaShopId ?? "";
+    const secretKey = (cfg as { yookassaSecretKey?: string | null }).yookassaSecretKey ?? "";
+    const externalId = body.object?.id ?? "";
+    const confirmed = await getYookassaPaymentStatus(shopId, secretKey, externalId);
+    if (confirmed.status !== "succeeded") {
+      console.warn("[YooKassa Webhook] Не подтверждено кассой — игнорируем", {
+        paymentId,
+        externalId,
+        status: confirmed.status,
+      });
+      return res.status(200).send("OK");
+    }
+    console.log("[YooKassa Webhook] Подтверждено запросом к кассе (Basic Auth не настроен)", { paymentId });
   }
 
   const payment = await prisma.payment.findFirst({

--- a/backend/src/modules/yookassa/yookassa.service.ts
+++ b/backend/src/modules/yookassa/yookassa.service.ts
@@ -324,3 +324,37 @@ export async function createYookassaAutopayment(params: AutopaymentParams): Prom
     return { ok: false, error: message };
   }
 }
+
+
+/**
+ * Статус платежа по данным самой ЮKassa.
+ *
+ * Нужен, когда уведомление пришло без Basic Auth: вместо того чтобы верить
+ * телу запроса, спрашиваем кассу напрямую. Возвращает статус (`succeeded`,
+ * `canceled`, `pending`…) либо null, если платёж не найден или касса недоступна.
+ */
+export async function getYookassaPaymentStatus(
+  shopId: string,
+  secretKey: string,
+  yookassaPaymentId: string,
+): Promise<{ status: string | null; amount: string | null }> {
+  if (!shopId?.trim() || !secretKey?.trim() || !yookassaPaymentId?.trim()) {
+    return { status: null, amount: null };
+  }
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 12_000);
+  try {
+    const auth = Buffer.from(`${shopId.trim()}:${secretKey.trim()}`).toString("base64");
+    const res = await fetch(`https://api.yookassa.ru/v3/payments/${encodeURIComponent(yookassaPaymentId.trim())}`, {
+      headers: { Authorization: `Basic ${auth}` },
+      signal: ctrl.signal,
+    });
+    if (!res.ok) return { status: null, amount: null };
+    const data = (await res.json()) as { status?: string; amount?: { value?: string } };
+    return { status: data?.status ?? null, amount: data?.amount?.value ?? null };
+  } catch {
+    return { status: null, amount: null };
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
В логах бесконечно:

```
[YooKassa Webhook] BASIC AUTH NOT CONFIGURED — REJECTING webhook
[YooKassa Webhook] Auth failed: no_credentials_configured
```

Деньги у кассы есть, подписка клиенту не выдана.

## Причина

Basic Auth у ЮKassa **опционален**, его включают далеко не все. Вебхук же отвергал такие уведомления с 401 — то есть на большинстве установок оплаты просто не зачислялись.

При этом просто вернуть «пропускать без проверки» нельзя: тогда кто угодно пришлёт «оплачено» и получит подписку бесплатно.

## Решение

Когда Basic Auth не настроен, уведомление не отвергается, но и телу запроса не верим: статус платежа подтверждается запросом к самой ЮKassa — `GET /v3/payments/{id}` нашими `shop_id` и `secret_key`. Зачисляем только при `succeeded`.

Подделать это нельзя: чужой платёж либо не найдётся в кассе, либо не будет `succeeded`.

Поведение в остальных случаях не меняется: настроенный Basic Auth проверяется как раньше, неверные реквизиты по-прежнему дают 401.

## Проверено

Выкачено на боевую установку с этой проблемой: отказы в логах прекратились, API здоров.