### PR TITLE
fix(security): хранимый XSS через вложения тикетов — кража сессии админа

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -297,6 +297,23 @@ app.get("/_spa", renderSpaIndex);
 app.use("/api/uploads", express.static(path.join("/app/uploads"), {
   maxAge: "30d",
   immutable: true,
+  setHeaders: (res, filePath) => {
+    // ⚠️ Хранимый XSS. Пользователь может приложить к тикету .svg — это XML,
+    // и внутрь вкладывается <script>. Файл отдаётся с домена панели, поэтому
+    // при открытии ссылки скрипт выполняется в её origin и читает токен
+    // из localStorage. Так у одной установки увели админскую сессию.
+    //
+    // sandbox без allow-scripts запрещает выполнение чего угодно в документе,
+    // nosniff не даёт браузеру угадать тип в обход заголовка.
+    res.setHeader("Content-Security-Policy", "default-src 'none'; sandbox");
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    // SVG не отдаём как изображение вовсе: даже с CSP это лишний риск.
+    // Картинки в интерфейсе не ломаются — там растровые форматы.
+    if (/\.svgz?$/i.test(filePath)) {
+      res.setHeader("Content-Type", "text/plain; charset=utf-8");
+      res.setHeader("Content-Disposition", "attachment");
+    }
+  },
 }));
 
 // Маркетплейс между админами: всегда монтируем, но хаб-роуты включаются только


### PR DESCRIPTION
Найдено на боевой установке: клиенту прислали «доказательство пентеста» — открытая ссылка на вложение показывала его `access_token`.

## Как это работает

1. Атакующий регистрируется обычным клиентом и создаёт тикет.
2. Прикладывает файл `.svg`. SVG — это XML, внутрь вкладывается `<script>`.
3. Файл отдаётся с домена панели: `/api/uploads/tickets/<id>.svg`, тип `image/svg+xml`.
4. Браузер открывает его **как документ** и выполняет скрипт **в origin панели**.
5. Скрипт читает `localStorage` — там лежит JWT — и выводит его.
6. С админским токеном атакующий получает панель целиком: клиенты, платежи, ключи Remnawave.

Сервер при этом не взломан и пароли не утекли — но результат тот же.

## Что поправлено

Правка сделана **на отдаче**, а не только на приёме: так обезвреживаются и файлы, уже лежащие на диске у пострадавших установок.

```
Content-Security-Policy: default-src 'none'; sandbox
X-Content-Type-Options: nosniff
```

`sandbox` без `allow-scripts` запрещает выполнение чего угодно в документе, `nosniff` не даёт браузеру угадать тип в обход заголовка. Дополнительно `.svg`/`.svgz` отдаются как `text/plain` с `Content-Disposition: attachment` — то есть скачиваются, а не открываются.

## Проверено на стенде

Положил такой же вредоносный SVG и запросил его:

```
content-type: text/plain; charset=utf-8
content-disposition: attachment
content-security-policy: default-src 'none'; sandbox
x-content-type-options: nosniff
```

Обычная картинка не сломалась — `image/png` отдаётся как прежде, интерфейс не затронут.

## Что стоит сделать дополнительно

Отсекать SVG ещё и на приёме (по сигнатуре файла, а не по расширению), и по-хорошему вынести пользовательские файлы на отдельный домен — тогда они физически не будут иметь доступа к сессии панели. Это отдельным заходом.