### PR TITLE
fix(install): чистая установка падала на миграциях

### DIFF
--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -221,6 +221,35 @@ if command -v psql >/dev/null 2>&1; then
   fi
 fi
 
+# ─── Сценарий 0: ЧИСТАЯ БАЗА (первая установка) ──────────────────────────
+# В истории миграций НЕТ начальной схемы — 29 таблиц из 57 (subscriptions,
+# tariffs, tickets, system_settings…) не создаёт ни одна миграция. Поэтому на
+# пустой БД migrate deploy доходит до 20250220_add_proxy_tariff_nodes, которая
+# вешает внешний ключ на proxy_tariffs, и падает с P3018 «relation does not
+# exist». После этого Prisma блокирует все миграции: api не становится healthy,
+# bot и nginx не стартуют по зависимости.
+#
+# Поэтому пустую БД создаём напрямую из schema.prisma и помечаем все миграции
+# применёнными. На непустой БД ветка не срабатывает — поведение не меняется.
+if command -v psql >/dev/null 2>&1; then
+  TABLES_PRESENT="$(psql "$DATABASE_URL" -tAc "SELECT count(*) FROM information_schema.tables WHERE table_schema='public'" 2>/dev/null || echo "")"
+  if [ "$TABLES_PRESENT" = "0" ]; then
+    log "БД пустая — создаю схему из schema.prisma и помечаю миграции применёнными"
+    if npx prisma db push --skip-generate --accept-data-loss >/tmp/dbpush.log 2>&1; then
+      for MIG_DIR in prisma/migrations/*/; do
+        MIG_NAME="$(basename "$MIG_DIR")"
+        [ "$MIG_NAME" = "*" ] && continue
+        npx prisma migrate resolve --applied "$MIG_NAME" >/dev/null 2>&1 || true
+      done
+      log "чистая БД подготовлена: схема создана, миграции baseline-нуты"
+    else
+      log "ОШИБКА: не удалось создать схему на пустой БД"
+      tail -20 /tmp/dbpush.log
+      exit 1
+    fi
+  fi
+fi
+
 if npx prisma migrate deploy >"$MIGRATE_LOG" 2>&1; then
   cat "$MIGRATE_LOG" || true
   log "migrate deploy: OK"


### PR DESCRIPTION
Человек ставит панель с нуля — бот не создаёт пользователей. На деле не стартует вообще ничего, кроме postgres.

## Что происходит

На пустой базе `migrate deploy` доходит до второй миграции `20250220_add_proxy_tariff_nodes`, которая вешает внешний ключ на `proxy_tariffs`:

```
Applying migration `20250220_add_proxy_tariff_nodes`
Error: P3018
ERROR: relation "proxy_tariffs" does not exist
```

Дальше Prisma блокирует все миграции, `api` не выходит в `healthy`, а `bot` и `nginx` не стартуют по зависимости от него. Пользователь видит «бот не работает», хотя бот даже не запущен — статус `Created`.

## Причина глубже одной миграции

В истории миграций **нет начальной схемы**: 29 таблиц из 57 не создаёт ни одна миграция — `subscriptions`, `tariffs`, `tickets`, `system_settings`, `refresh_tokens`, `promo_codes` и другие. База всегда существовала до них, поэтому на апгрейдах это не всплывало.

Восстановление в `docker-entrypoint.sh` покрывает семь сценариев (P3005, P3009, P3018 после отката и так далее), но ветки «база пустая» среди них не было — `migrate deploy` вызывался сразу.

## Что сделано

Добавлена ветка для чистой базы: схема создаётся напрямую из `schema.prisma`, все миграции помечаются применёнными, дальше всё идёт обычным путём. Срабатывает **только** когда в `public` ноль таблиц — существующие установки не затронуты.

## Проверено на стенде

Создал реально пустую базу и запустил на ней:

```
[docker-entrypoint] чистая БД подготовлена: схема создана, миграции baseline-нуты
No pending migrations to apply.
[docker-entrypoint] migrate deploy: OK
[seed] English language pack seeded
```

58 таблиц, API стартовал. Без правки — P3018 и блокировка.

## Что стоит сделать отдельно

Правильнее добавить в историю недостающую начальную миграцию, чтобы `migrate deploy` был самодостаточным. Это отдельная работа, здесь я закрываю сам симптом — сломанную установку с нуля.