### PR TITLE
fix(broadcast): SVG-вложение падало у всех получателей + задание висело в очереди вечно

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -16,6 +16,7 @@ import { startAutoRenewScheduler } from "./modules/payment/auto-renew.cron.js";
 import { startAutoBackupScheduler, stopAutoBackupScheduler } from "./modules/backup/auto-backup.scheduler.js";
 import { startGiftExpiryCron } from "./modules/gift/gift-expiry.cron.js";
 import { startMarketplaceScheduler, stopMarketplaceScheduler } from "./modules/marketplace/marketplace.scheduler.js";
+import { startBroadcastStaleScheduler, stopBroadcastStaleScheduler } from "./modules/broadcast/broadcast-stale.scheduler.js";
 import { ensureTheme, seedDefaultsToEmptyBlocks } from "./modules/landing/landing.service.js";
 import { migrateLandingToBlocks } from "./scripts/migrate-landing-to-blocks.js";
 import { migrateRemnaIds } from "./scripts/migrate-remna-ids.js";
@@ -67,6 +68,7 @@ async function main() {
   // TG-юзерам для запуска онбординга (см. /telegram-login-check, /register). Крон бы их стирал.
   await startAutoBackupScheduler();
   startMarketplaceScheduler();
+  startBroadcastStaleScheduler();
 
   // Регистрация cron-задач в реестре для UI /admin/diagnostics → Cron monitor.
   // Имена/cron-выражения зашиты — должны соответствовать defaults в каждом scheduler.
@@ -90,6 +92,7 @@ async function main() {
 
   const shutdown = async () => {
     stopAutoBroadcastScheduler();
+    stopBroadcastStaleScheduler();
     stopContestDailyReminderScheduler();
     stopAutoBackupScheduler();
     stopMarketplaceScheduler();

--- a/backend/src/modules/broadcast/broadcast-stale.scheduler.ts
+++ b/backend/src/modules/broadcast/broadcast-stale.scheduler.ts
@@ -1,0 +1,76 @@
+/**
+ * Страховка от «рассылка началась и висит».
+ *
+ * API только кладёт задание в очередь (status='pending'), а забирает его
+ * отдельный сервис broadcast-worker. Если после обновления не прогнали
+ * `docker compose up -d`, контейнера broadcast-worker просто нет — задание
+ * лежит в очереди вечно, и никакой ошибки нигде не появляется: в админке
+ * бесконечный прогресс, в логах тишина. Поймано на боевой установке, где
+ * рассылка провисела 19 часов и закрылась только кнопкой отмены.
+ *
+ * Сам воркер такое заметить не может — он же и не запущен. Поэтому сторожа
+ * держим в API.
+ *
+ * Осторожно с гонками: при рестарте воркер возвращает недоделанную рассылку в
+ * 'pending' со СТАРЫМ started_at, и живой воркер подхватывает её за ~3 секунды.
+ * Поэтому (а) первую проверку не делаем на старте, а только через интервал, и
+ * (б) в UPDATE повторно требуем status='pending', чтобы не затоптать задание,
+ * которое забрали между выборкой и записью.
+ */
+
+import { prisma } from "../../db.js";
+
+const CHECK_INTERVAL_MS = 5 * 60 * 1000;
+const STALE_AFTER_MS = 15 * 60 * 1000;
+
+const HINT =
+  "Рассылку никто не забрал из очереди — похоже, не запущен сервис broadcast-worker " +
+  "(проверьте `docker compose ps broadcast-worker`, поднимите `docker compose up -d`)";
+
+let timer: NodeJS.Timeout | null = null;
+
+async function sweepStalePending(): Promise<void> {
+  const threshold = new Date(Date.now() - STALE_AFTER_MS);
+  const stuck = await prisma.broadcastHistory.findMany({
+    where: { status: "pending", startedAt: { lt: threshold } },
+    select: { id: true, startedAt: true },
+  });
+  if (stuck.length === 0) return;
+
+  const minutes = Math.round(STALE_AFTER_MS / 60000);
+  console.error(
+    `[broadcast-stale] ${stuck.length} рассылок висят в очереди дольше ${minutes} мин — ` +
+      `${HINT}. id: ${stuck.map((s) => s.id).join(", ")}`,
+  );
+
+  const res = await prisma.broadcastHistory.updateMany({
+    where: { id: { in: stuck.map((s) => s.id) }, status: "pending" },
+    data: { status: "error", finishedAt: new Date(), error: HINT },
+  });
+  if (res.count > 0) {
+    console.error(`[broadcast-stale] помечено ошибкой: ${res.count}`);
+  }
+}
+
+export function startBroadcastStaleScheduler(): void {
+  if (timer) return;
+  // Намеренно НЕ проверяем сразу на старте: если стек поднимается целиком,
+  // воркеру нужно несколько секунд, чтобы забрать возвращённые в очередь
+  // задания. Первая проверка — через интервал.
+  timer = setInterval(() => {
+    void sweepStalePending().catch((e) => {
+      console.error("[broadcast-stale] проверка не удалась:", e instanceof Error ? e.message : e);
+    });
+  }, CHECK_INTERVAL_MS);
+  console.log(
+    `[broadcast-stale] Scheduler started: проверка раз в ${Math.round(CHECK_INTERVAL_MS / 60000)} мин, ` +
+      `порог ${Math.round(STALE_AFTER_MS / 60000)} мин`,
+  );
+}
+
+export function stopBroadcastStaleScheduler(): void {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+}

--- a/backend/src/modules/broadcast/broadcast.service.ts
+++ b/backend/src/modules/broadcast/broadcast.service.ts
@@ -136,9 +136,23 @@ export async function sendDirectEmail(to: string, subject: string | undefined, m
   return send.ok ? { ok: true } : { ok: false, error: send.error };
 }
 
+// Telegram sendPhoto принимает только растровые форматы. SVG, HEIC/HEIF, TIFF и
+// иконки он отвергает с «Bad Request: IMAGE_PROCESS_FAILED», причём на КАЖДОГО
+// получателя — рассылка уходит в ноль отправленных и выглядит как «ничего не
+// работает». Такие вложения шлём документом: картинкой в ленте не станет, зато
+// дойдёт до человека. mime может нести параметры («image/svg+xml; charset=…»),
+// поэтому сверяем только тип до точки с запятой.
+const TELEGRAM_NON_PHOTO_IMAGE =
+  /^image\/(svg\+xml|svg|heic|heif|heic-sequence|heif-sequence|tiff|x-tiff|x-icon|vnd\.microsoft\.icon)$/i;
+
+function isTelegramPhoto(mimetype: string | undefined): boolean {
+  if (!mimetype?.startsWith("image/")) return false;
+  return !TELEGRAM_NON_PHOTO_IMAGE.test(mimetype.split(";")[0].trim());
+}
+
 // Одноразовая подготовка media-параметров (тип + probe видео + thumbnail) перед отправкой.
 function prepareMedia(att: BroadcastAttachment | undefined) {
-  const isImage = att?.mimetype?.startsWith("image/") ?? false;
+  const isImage = isTelegramPhoto(att?.mimetype);
   const isVideo = att?.mimetype?.startsWith("video/") ?? false;
   const videoMeta = isVideo && att ? probeVideoMetaSync(att.buffer, att.originalname) : {};
   const videoThumb = isVideo && att ? generateVideoThumbnail(att.buffer, att.originalname) : null;
@@ -669,7 +683,7 @@ export async function runBroadcast(options: {
   const config = await getSystemConfig();
   const doTelegram = channel === "telegram" || channel === "both";
   const doEmail = channel === "email" || channel === "both";
-  const isImage = attachment?.mimetype?.startsWith("image/") ?? false;
+  const isImage = isTelegramPhoto(attachment?.mimetype);
   // 25.05.2026, WolfVPN — добавили ветку video/* → sendVideo (нативный плеер
   // с превью в Telegram, в отличие от sendDocument где видео — просто файл).
   const isVideo = attachment?.mimetype?.startsWith("video/") ?? false;


### PR DESCRIPTION
Две независимые беды, найденные при разборе боевой установки. Снаружи выглядят одинаково — «рассылка не работает», — но причины разные и чинятся порознь.

## 1. Вложение SVG уходило в ноль отправленных

Способ отправки выбирался по префиксу mime:

```ts
const isImage = attachment?.mimetype?.startsWith("image/") ?? false;   // image/svg+xml -> sendPhoto
```

Под это подходит и `image/svg+xml`, а Telegram растеризовать SVG не умеет — отвечает `Bad Request: IMAGE_PROCESS_FAILED` на **каждого** получателя. В истории рассылка помечена `completed`, но `sent=0, failed=N`, и админ видит просто «ничего не дошло».

С боевой установки:

```
errors | ["Telegram 6880107520: Bad Request: IMAGE_PROCESS_FAILED",
          "Telegram 1275500904: Bad Request: IMAGE_PROCESS_FAILED", ...]
sent_telegram | 0     failed_telegram | 5     attachment_mime | image/svg+xml
```

Те же грабли у `heic`/`heif`, `tiff` и иконок. Теперь такие типы уходят через `sendDocument` — картинкой в ленте не станет, зато дойдёт до человека. Мест было два (`prepareMedia` и основной путь), вынесено в общий предикат `isTelegramPhoto()`; `mime` может нести параметры (`image/svg+xml; charset=utf-8`), поэтому сверяется только тип до точки с запятой.

## 2. Рассылка «начиналась и висела» без единой ошибки

API только кладёт задание в очередь (`status='pending'`), забирает его отдельный сервис `broadcast-worker`. Если после обновления не прогнать `docker compose up -d`, контейнера нет вовсе — задание лежит в очереди вечно: в админке бесконечный прогресс, в логах `[broadcast] queued: …` без парной `claimed`, и больше ничего.

На боевой установке рассылка провисела **19 ч 49 мин** и закрылась только кнопкой отмены. Диагностику это сбивает полностью: `docker ps` показывает бодрое «Up 3 hours» у всех контейнеров, потому что отсутствующий контейнер там просто не перечислен.

Сам воркер такое заметить не может — он же и не запущен. Поэтому сторож живёт в API: раз в 5 минут ищет задания в `pending` старше 15 минут, помечает ошибкой и пишет в лог, что именно проверить.

**Гонки учтены.** При рестарте воркер возвращает недоделанную рассылку в `pending` со старым `started_at`, а живой воркер подхватывает её за ~3 секунды. Чтобы не убить законную длинную рассылку:

- первая проверка **не** делается на старте, только через интервал — живой воркер к тому моменту уже заберёт задание;
- в `UPDATE` повторно требуется `status='pending'`, так что задание, забранное между выборкой и записью, не затирается.

## Проверка на стенде

- сборка образа проходит, типы чистые;
- маршрутизация mime:

| mime | куда идёт |
|---|---|
| `image/png`, `image/jpeg`, `image/webp`, `image/gif` | `sendPhoto` (как было) |
| `image/svg+xml`, в том числе с `; charset=utf-8` | документом |
| `image/heic`, `image/tiff`, `image/x-icon` | документом |
| `video/*`, `application/pdf` | не задеты |

- api поднимается, в логе `[broadcast-stale] Scheduler started: проверка раз в 5 мин, порог 15 мин`, ошибок нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)