### PR TITLE
fix(broadcast): опрос статуса не завершался никогда и выжигал лимит запросов на весь /api

### DIFF
--- a/backend/src/modules/broadcast/broadcast.service.ts
+++ b/backend/src/modules/broadcast/broadcast.service.ts
@@ -1014,6 +1014,11 @@ export async function startBroadcastJob(options: {
  * 25.05.2026, WolfVPN — статус ТЕПЕРЬ читается из DB, а не из in-memory map
  * (рассылка теперь в отдельном worker-процессе, in-memory map api не виден).
  */
+/** терминальный статус — работа окончена, итог больше не изменится */
+function isTerminalBroadcastStatus(status: string): boolean {
+  return status === "completed" || status === "cancelled" || status === "error";
+}
+
 export async function getBroadcastJob(jobId: string): Promise<BroadcastJob | null> {
   const row = await prisma.broadcastHistory.findUnique({ where: { id: jobId } });
   if (!row) return null;
@@ -1031,6 +1036,23 @@ export async function getBroadcastJob(jobId: string): Promise<BroadcastJob | nul
       failedTelegram: row.failedTelegram,
       failedEmail: row.failedEmail,
     },
+    // Итог отдаём, когда статус терминальный. При переезде задач из памяти в БД
+    // это поле перестали заполнять, а фронт ждёт именно его: условие выхода из
+    // опроса — `status === "completed" && result`. Без result опрос крутился до
+    // 30-минутного дедлайна по запросу каждые 1.5 с — ~1200 запросов на одну
+    // рассылку при общем лимите 1500/15 мин. Пара рассылок клала всю админку в
+    // 429, вплоть до невозможности войти.
+    result: isTerminalBroadcastStatus(row.status)
+      ? {
+          ok: row.status === "completed",
+          sentTelegram: row.sentTelegram,
+          sentEmail: row.sentEmail,
+          failedTelegram: row.failedTelegram,
+          failedEmail: row.failedEmail,
+          errors: Array.isArray(row.errors) ? (row.errors as string[]) : [],
+          ...(row.status === "cancelled" ? { cancelled: true } : {}),
+        }
+      : undefined,
     cancelRequested: row.cancelRequested,
   };
 }

--- a/frontend/src/pages/broadcast.tsx
+++ b/frontend/src/pages/broadcast.tsx
@@ -315,13 +315,26 @@ export function BroadcastPage() {
   }
 
   async function pollBroadcastJob(jobId: string): Promise<BroadcastResult> {
-    const deadline = Date.now() + 30 * 60 * 1000;
+    const startedAt = Date.now();
+    const deadline = startedAt + 30 * 60 * 1000;
     while (Date.now() < deadline) {
       try {
         const s = await api.broadcastStatus(token, jobId);
         if (s.progress) setBroadcastProgress(s.progress);
         if (s.cancelRequested) setBroadcastCancelRequested(true);
-        if (s.status === "completed" && s.result) return s.result;
+        // Выходим на завершении ВСЕГДА — даже если result почему-то не пришёл.
+        // Раньше условие требовало и то и другое, и одно пустое поле подвешивало
+        // опрос на все 30 минут, выжигая общий лимит запросов на весь /api.
+        if (s.status === "completed") {
+          return s.result ?? {
+            ok: true,
+            sentTelegram: s.progress?.sentTelegram ?? 0,
+            sentEmail: s.progress?.sentEmail ?? 0,
+            failedTelegram: s.progress?.failedTelegram ?? 0,
+            failedEmail: s.progress?.failedEmail ?? 0,
+            errors: [],
+          };
+        }
         if (s.status === "cancelled") {
           // 19.05.2026, WolfVPN — рассылка прервана админом, возвращаем то что успели.
           return {
@@ -347,7 +360,11 @@ export function BroadcastPage() {
       } catch {
         // network blip — retry
       }
-      await new Promise((r) => setTimeout(r, 1500));
+      // Первые две минуты опрашиваем часто (почти все рассылки укладываются
+      // в секунды), дальше реже: длинная рассылка на 1.5 с съедала бы ~1200
+      // запросов и в одиночку упиралась в лимит /api.
+      const elapsed = Date.now() - startedAt;
+      await new Promise((r) => setTimeout(r, elapsed < 2 * 60 * 1000 ? 1500 : 5000));
     }
     return {
       ok: false,


### PR DESCRIPTION
Со стороны клиента это выглядит так: админка пишет **«Ошибка загрузки»** на `/admin/settings` и на любой другой странице. В логах nginx все админские вызовы отдают `429`, включая `POST /api/auth/login` — в панель нельзя даже войти.

Соблазнительно списать на лимитер. Но он ни при чём.

## Что происходит на самом деле

При переезде задач рассылки из памяти в БД функция `getBroadcastJob` перестала заполнять поле `result` — она возвращает `id`/`status`/`progress`/`error`/`cancelRequested`, а `result` в типе `BroadcastJob` необязательный и просто не проставляется. Эндпоинт отдаёт `result: job.result ?? null`, то есть **всегда null**.

А условие выхода из опроса во фронте:

```ts
if (s.status === "completed" && s.result) return s.result;
```

Оно не может выполниться никогда. Опрос крутится каждые 1.5 с до 30-минутного дедлайна — **≈1200 запросов на одну рассылку** при общем лимите 1500 за 15 минут. Одна-две рассылки исчерпывают бюджет, и дальше вся панель получает 429.

## Замер на боевой установке

Рассылка завершилась за 3 секунды:

```
17a3d8ac | completed | 5 всего | 5 отпр | 0 пров | 19:21:37 -> 19:21:40
```

А опрос её статуса шёл ещё **15 минут**, 647 запросов, с растущим темпом:

```
19:21  13     19:26  33     19:31  54
19:22  35     19:27  36     19:32  60
19:23  35     19:28  36     19:33  59
19:24  36     19:29  38     19:34  59
19:25  36     19:30  52     19:35  52
```

Первый `429` — в 19:35:56, через 14 минут после начала опроса. То есть **429 это следствие, а не причина**.

## Правки

| где | что |
|---|---|
| backend | `getBroadcastJob` отдаёт `result` на терминальных статусах (`completed`/`cancelled`/`error`), собирая его из строки БД; для `cancelled` проставляется `cancelled: true` |
| frontend | выходим из опроса на `completed` **даже если `result` не пришёл** — чтобы одно пустое поле больше не могло подвесить опрос на полчаса |
| frontend | первые две минуты опрашиваем каждые 1.5 с, дальше каждые 5 с |

Притормаживание нужно отдельно от основного фикса: длинная рассылка на прежнем темпе съедала бы те же ~1200 запросов и в одиночку упиралась в лимит. Теперь получасовая укладывается примерно в 420, а прогресс в первые минуты (когда почти все рассылки и заканчиваются) обновляется как раньше.

Лимитер намеренно **не трогал**: 1500 запросов за 15 минут — разумный бюджет, чинить надо было опрос.

## Проверка

- стенд: сборка `api` и `frontend` проходит, типы чистые, api поднимается healthy;
- боевая установка: перезапуск api снял залипший счётчик — `/api/admin/settings` отвечает `401` вместо `429`, панель открывается.

🤖 Generated with [Claude Code](https://claude.com/claude-code)