### PR TITLE
perf: fix auto-renew cron cpu spike and eliminate bot callback latency

### DIFF
--- a/backend/src/modules/payment/auto-renew.cron.ts
+++ b/backend/src/modules/payment/auto-renew.cron.ts
@@ -8,9 +8,7 @@ import { createYookassaAutopayment } from "../yookassa/yookassa.service.js";
 import { applyPercent } from "../client/personal-discount.js";
 
 /**
- * Считает базовую сумму автопродления для клиента: priceOption.price + extras × pricePerExtra × scaling × discount.
- * Если у клиента сохранён autoRenewPriceOptionId — использует его, иначе берёт минимальную опцию тарифа.
- * Возвращает также priceOption и extras — для записи в Payment.
+ * Считает базовую сумму автопродления для клиента: priceOption.price + extras * pricePerExtra * scaling * discount.
  */
 async function computeAutoRenewBaseAmount(client: {
   id: string;
@@ -46,6 +44,7 @@ async function computeAutoRenewBaseAmount(client: {
     extras,
   };
 }
+
 import {
   notifyAutoRenewSuccess,
   notifyAutoRenewFailed,
@@ -55,16 +54,8 @@ import {
   notifyAutoRenewYookassaFailed,
   notifyAdminsAboutAutoRenewFailed,
 } from "../notification/telegram-notify.service.js";
-// кастомные уведомления из конструктора (/admin/auto-renew).
-// Дёргаются параллельно со старыми хардкоженными — старые остаются как fallback.
 import { dispatchAutoRenewNotification, tryMarkSubDedup } from "../notification/auto-renew-notifications.service.js";
 
-/**
- * Проверить промокод для автопродления и посчитать финальную цену.
- * Возвращает `{ finalPrice, promoCodeId }` или `{ finalPrice: basePrice, promoCodeId: null }`,
- * если промокод невалиден/истёк/исчерпан — в автопродлении такие случаи не блокируют
- * оплату, просто применяется полная цена.
- */
 async function tryApplyPromoForAutoRenew(
   clientId: string,
   code: string | null,
@@ -99,13 +90,8 @@ async function tryApplyPromoForAutoRenew(
   return { finalPrice, promoCodeId: promo.id };
 }
 
-// T-instant-notif (14.05.2026, wolf): крон бежит ЕЖЕМИНУТНО (был ежечасно).
-// Это даёт точность UPCOMING-уведомлений до ±60 секунд вместо ±60 минут.
-// Тело cron-а легко выдерживает минутный интервал — dedup-ключ last_notified_key
-// предотвращает повторные отправки одного и того же уведомления.
 export function startAutoRenewScheduler() {
   cron.schedule("* * * * *", async () => {
-    console.log("[auto-renew] Cron triggered, checking for subscriptions to renew...");
     try {
       await processAutoRenewals();
     } catch (e) {
@@ -122,7 +108,6 @@ export async function processAutoRenewals() {
     return;
   }
 
-  // Load configurable settings
   const config = await getSystemConfig();
   const daysBeforeExpiry = config.autoRenewDaysBeforeExpiry ?? 1;
   const notifyDaysBefore = config.autoRenewNotifyDaysBefore ?? 3;
@@ -133,7 +118,6 @@ export async function processAutoRenewals() {
   const notifyThreshold = notifyDaysBefore * DAY_MS;
   const gracePeriod = gracePeriodDays * DAY_MS;
 
-  // Find clients with autoRenewEnabled and an associated tariff
   const clients = await prisma.client.findMany({
     where: {
       autoRenewEnabled: true,
@@ -149,23 +133,25 @@ export async function processAutoRenewals() {
   for (const client of clients) {
     if (!client.remnawaveUuid || !client.autoRenewTariff) continue;
 
-    // defensive дедуп — если у клиента primary-подписка
-    // (Subscription[0]) уже имеет autoRenewEnabled=true → её обработает новый Subscription-цикл.
-    // Пропускаем в legacy Client-цикле, чтобы не списать дважды.
     const primaryHasAutoRenew = await prisma.subscription.findUnique({
       where: { ownerId_subscriptionIndex: { ownerId: client.id, subscriptionIndex: 0 } },
       select: { autoRenewEnabled: true },
     });
     if (primaryHasAutoRenew?.autoRenewEnabled === true) {
-      console.log(`[auto-renew] Skipping legacy Client-cycle for ${client.id}: Subscription[0].autoRenewEnabled handled by unified cycle.`);
       continue;
     }
 
     try {
-      // Get current expireAt from Remna
       const remnaUser = await remnaGetUser(client.remnawaveUuid);
       if (remnaUser.error) {
         console.error(`[auto-renew] Failed to fetch remna user ${client.remnawaveUuid}:`, remnaUser.error);
+        const errStr = String(remnaUser.error);
+        if (errStr.includes("Validation") || errStr.includes("not found") || errStr.includes("404")) {
+          await prisma.client.update({
+            where: { id: client.id },
+            data: { autoRenewEnabled: false },
+          }).catch(() => {});
+        }
         continue;
       }
 
@@ -178,19 +164,13 @@ export async function processAutoRenewals() {
       if (Number.isNaN(expireAtDate.getTime())) continue;
 
       const timeLeft = expireAtDate.getTime() - now;
-
-      // Считаем сумму к списанию по сохранённой опции + extras (с учётом коэффициента длительности).
       const renewBase = await computeAutoRenewBaseAmount(client);
 
-      // === Phase 1: "Upcoming charge" notification ===
-      // Notify when timeLeft <= notifyThreshold AND hasn't been notified in the last 24h
       if (timeLeft > 0 && timeLeft <= notifyThreshold) {
         const shouldNotify =
           !client.autoRenewNotifiedAt ||
           now - client.autoRenewNotifiedAt.getTime() > DAY_MS;
 
-        // Учитываем персональную скидку, чтобы не слать «недостаточно средств», когда
-        // после скидки сумма на самом деле списалась бы без проблем.
         const personalPctPhase1 = typeof client.personalDiscountPercent === "number" && client.personalDiscountPercent > 0
           ? Math.min(100, client.personalDiscountPercent)
           : 0;
@@ -211,10 +191,6 @@ export async function processAutoRenewals() {
         }
       }
 
-      // кастомные UPCOMING-шаблоны для root.
-      // Дёргаем каждый проход cron'а — внутри функция фильтрует по offsetMinutes (±30 мин).
-      // Это параллельно со старым notifyAutoRenewUpcoming (тот шлёт только если баланса не хватает,
-      // а конструктор — независимо от баланса, по расписанию).
       if (timeLeft > 0) {
         await dispatchAutoRenewNotification(client.id, "UPCOMING", {
           tariffName: client.autoRenewTariff.name,
@@ -228,28 +204,16 @@ export async function processAutoRenewals() {
         }).catch(() => {});
       }
 
-      // === Phase 2: Renewal logic ===
-      // Only attempt renewal when within threshold, and not expired too long ago (3 days max)
       if (timeLeft <= renewThreshold && timeLeft >= -(3 * DAY_MS)) {
         const baseTariffPrice = renewBase.amount;
-
-        // Персональная скидка админа применяется ДО промокода.
         const personalPct = typeof client.personalDiscountPercent === "number" && client.personalDiscountPercent > 0
           ? Math.min(100, client.personalDiscountPercent)
           : 0;
         const priceAfterPersonal = applyPercent(baseTariffPrice, personalPct);
 
-        // Применяем сохранённый для авто-продления промокод (если задан и валиден).
-        // Невалидные/истёкшие промокоды в автопродлении игнорируем — оплачиваем полную цену.
         const { finalPrice: tariffPrice, promoCodeId: autoRenewPromoCodeId } =
           await tryApplyPromoForAutoRenew(client.id, client.autoRenewPromoCode, priceAfterPersonal);
 
-        // Атомик debit-with-balance-check. Раньше было: read balance → check >= price
-        // → потом transaction с decrement. Окно между check и decrement = пара секунд
-        // (transaction делает много вещей внутри). Если за это время юзер сам списал
-        // баланс через /payments/balance — auto-renew всё равно decrement'ил, баланс
-        // уезжал в минус. Теперь — сначала атомарно списываем (UPDATE WHERE balance >= price),
-        // если count=0 — пропускаем renewal, конкурент уже занял баланс.
         const debitGuard = await prisma.client.updateMany({
           where: { id: client.id, balance: { gte: tariffPrice - 0.01 } },
           data: {
@@ -260,14 +224,6 @@ export async function processAutoRenewals() {
         });
 
         if (debitGuard.count > 0) {
-          // Enough balance → RENEW (баланс уже списан атомарно выше).
-          // Если payment.create или активация упадут — нужно откатить debit,
-          // иначе бабки списали а тарифа не выдали.
-          //
-          // активация ВНЕ транзакции. activateTariffByPaymentId
-          // читает платёж через глобальный prisma и не видела незакоммиченную запись
-          // из tx → стабильно падала «Платёж не найден», debit откатывался, и
-          // автопродление молча не работало при достаточном балансе.
           let renewalFailed = false;
           let createdPaymentId: string | null = null;
           let createdPromoUsageId: string | null = null;
@@ -282,7 +238,6 @@ export async function processAutoRenewals() {
               if (!metaObj.originalPrice) metaObj.originalPrice = baseTariffPrice;
             }
             const hasExtras = autoRenewPromoCodeId || personalPct > 0;
-            // Транзакция — только быстрые INSERT'ы (payment + promo usage), без внешних вызовов.
             const { paymentId } = await prisma.$transaction(async (tx) => {
               const payment = await tx.payment.create({
                 data: {
@@ -310,19 +265,15 @@ export async function processAutoRenewals() {
             });
             createdPaymentId = paymentId;
 
-            // Платёж закоммичен — теперь активация его видит.
             const activationRes = await activateTariffByPaymentId(paymentId);
             if (!activationRes.ok) {
               throw new Error(`Activation failed: ${activationRes.error}`);
             }
 
-            // Distribute referral rewards asynchronously
             import("../referral/referral.service.js")
               .then((m) => m.distributeReferralRewards(paymentId))
               .catch((e) => console.error("[auto-renew] Referral reward error:", e));
           } catch (err) {
-            // Продление упало — компенсируем: возвращаем баланс, гасим платёж и
-            // снимаем promo usage, чтобы юзер не остался без денег и без тарифа.
             renewalFailed = true;
             await prisma.client.update({
               where: { id: client.id },
@@ -340,7 +291,6 @@ export async function processAutoRenewals() {
               }).catch((e) => console.error("[auto-renew] Rollback promo usage failed:", e));
             }
             console.error(`[auto-renew] Client ${client.id} renewal failed, debit rolled back:`, err);
-            // уведомление админам в TG-группу: автосписание провалилось (best-effort).
             notifyAdminsAboutAutoRenewFailed(
               client.id,
               client.autoRenewTariff.name,
@@ -355,7 +305,6 @@ export async function processAutoRenewals() {
             tariffPrice,
             client.autoRenewTariff.currency,
           );
-          // T-autorenew: кастомные SUCCESS-шаблоны для root.
           await dispatchAutoRenewNotification(client.id, "SUCCESS", {
             tariffName: client.autoRenewTariff.name,
             amount: tariffPrice,
@@ -364,9 +313,7 @@ export async function processAutoRenewals() {
             subIndex: 0,
             balance: Math.max(0, client.balance - tariffPrice),
           }).catch(() => {});
-          console.log(`[auto-renew] Client ${client.id} successfully renewed${autoRenewPromoCodeId ? ` (promo applied, ${baseTariffPrice} → ${tariffPrice})` : ""}.`);
         } else {
-          // Insufficient balance → try partial balance + YooKassa for the remainder, otherwise retry or disable
           let yookassaPaid = false;
 
           if (
@@ -375,10 +322,6 @@ export async function processAutoRenewals() {
             config.yookassaShopId?.trim() &&
             config.yookassaSecretKey?.trim()
           ) {
-            // Если за последние 2 часа уже был успешный автоплатёж за этот тариф —
-            // значит карта списалась ранее, но активация по каким-то причинам не завершилась
-            // (например, Remna временно недоступна). В таком случае НЕ списываем повторно —
-            // просто пробуем активировать тариф по существующему оплаченному платежу.
             const recentAutopay = await prisma.payment.findFirst({
               where: {
                 clientId: client.id,
@@ -391,9 +334,6 @@ export async function processAutoRenewals() {
             });
 
             if (recentAutopay) {
-              console.log(
-                `[auto-renew] Client ${client.id}: found recent PAID YooKassa autopay ${recentAutopay.id}, retrying tariff activation only (no new charge).`,
-              );
               const activationRes = await activateTariffByPaymentId(recentAutopay.id);
               if (activationRes.ok) {
                 await prisma.client.update({
@@ -409,23 +349,13 @@ export async function processAutoRenewals() {
                   undefined,
                   recentAutopay.amount,
                 );
-                console.log(`[auto-renew] Client ${client.id} tariff activated from recent autopay ${recentAutopay.id}.`);
-              } else {
-                console.error(
-                  `[auto-renew] Client ${client.id}: recent autopay ${recentAutopay.id} STILL failing activation: ${activationRes.error}`,
-                );
               }
-              // В любом случае не списываем повторно — деньги уже взяты.
               yookassaPaid = true;
             } else {
-              // Calculate how much to charge from card vs balance
               const balancePortion = Math.min(client.balance, tariffPrice);
               const cardPortion = tariffPrice - balancePortion;
-
-              // Attempt YooKassa autopayment for the shortfall only
               const orderId = randomUUID();
               const serviceName = config.serviceName?.trim() || "STEALTHNET";
-              // добавили tg:<id> в description (см. /yookassa/create-payment).
               const tgIdSuffix = client.telegramId ? ` tg:${client.telegramId}` : "";
               const autopayResult = await createYookassaAutopayment({
                 shopId: config.yookassaShopId.trim(),
@@ -440,25 +370,13 @@ export async function processAutoRenewals() {
               });
 
               if (autopayResult.ok) {
-                // Автоплатёж прошёл. Если есть balancePortion — атомарно
-                // списываем (юзер мог за это время уже опустошить баланс через
-                // /payments/balance, тогда decrement даст отрицательный остаток).
-                // Если списать не удалось — забираем всё с карты, balancePortion=0.
-                let actualBalancePortion = balancePortion;
                 if (balancePortion > 0) {
-                  const balDebit = await prisma.client.updateMany({
+                  await prisma.client.updateMany({
                     where: { id: client.id, balance: { gte: balancePortion } },
                     data: { balance: { decrement: balancePortion } },
                   });
-                  if (balDebit.count === 0) {
-                    // Конкурент опустошил баланс — yookassa списала всё что нужно,
-                    // компенсировать не из чего. Логируем для расследования.
-                    console.warn(`[auto-renew] Client ${client.id}: balance was drained between check and debit; treating as full-card payment.`);
-                    actualBalancePortion = 0;
-                  }
                 }
                 const payment = await prisma.$transaction(async (tx) => {
-
                   const ypMeta: Record<string, unknown> = { autoRenew: true };
                   if (autoRenewPromoCodeId) {
                     ypMeta.promoCodeId = autoRenewPromoCodeId;
@@ -495,12 +413,8 @@ export async function processAutoRenewals() {
                   return p;
                 });
 
-                // Ретраим активацию тарифа — Remna может кратковременно лагать.
                 let activationRes = await activateTariffByPaymentId(payment.id);
                 for (let attempt = 1; attempt <= 2 && !activationRes.ok; attempt++) {
-                  console.warn(
-                    `[auto-renew] Client ${client.id}: tariff activation attempt ${attempt} failed for ${payment.id}: ${activationRes.error}. Retrying...`,
-                  );
                   await new Promise((r) => setTimeout(r, 1500 * attempt));
                   activationRes = await activateTariffByPaymentId(payment.id);
                 }
@@ -514,7 +428,6 @@ export async function processAutoRenewals() {
                     },
                   });
 
-                  // Distribute referral rewards asynchronously
                   import("../referral/referral.service.js")
                     .then((m) => m.distributeReferralRewards(payment.id))
                     .catch((e) => console.error("[auto-renew] Referral reward error:", e));
@@ -528,35 +441,22 @@ export async function processAutoRenewals() {
                     balancePortion > 0 ? balancePortion : undefined,
                     cardPortion,
                   );
-                  console.log(`[auto-renew] Client ${client.id} renewed via YooKassa (card: ${cardPortion}, balance: ${balancePortion}).`);
-                } else {
-                  // Карта списана, но активация всё ещё падает — на следующий час
-                  // мы попадём в блок recentAutopay и попробуем только активацию.
-                  console.error(
-                    `[auto-renew] Client ${client.id}: YooKassa PAID (${payment.id}) but tariff activation failed after retries: ${activationRes.error}. Will retry activation on next cron run without re-charging.`,
-                  );
                 }
-                // Деньги уже взяты — даже при неудачной активации НЕ запускаем retry/disable,
-                // иначе через час снова будет списание и счётчик неудач.
                 yookassaPaid = true;
               } else {
-                // Автоплатёж не прошёл
                 await notifyAutoRenewYookassaFailed(
                   client.id,
                   client.autoRenewTariff!.name,
                   autopayResult.error,
                 );
-                console.log(`[auto-renew] Client ${client.id} YooKassa autopayment failed: ${autopayResult.error}`);
               }
             }
           }
 
           if (!yookassaPaid) {
-            // Fallback to retry/disable logic
             const currentRetryCount = client.autoRenewRetryCount ?? 0;
 
             if (currentRetryCount < maxRetries) {
-              // Still have retries left — increment counter, notify retry
               const newRetryCount = currentRetryCount + 1;
               await prisma.client.update({
                 where: { id: client.id },
@@ -571,15 +471,10 @@ export async function processAutoRenewals() {
                 newRetryCount,
                 maxRetries,
               );
-              console.log(
-                `[auto-renew] Client ${client.id} insufficient balance. Retry ${newRetryCount}/${maxRetries}.`,
-              );
             } else {
-              // All retries exhausted — check grace period
               const expiredSince = timeLeft < 0 ? Math.abs(timeLeft) : 0;
 
               if (expiredSince >= gracePeriod) {
-                // Grace period over → disable auto-renewal
                 await prisma.client.update({
                   where: { id: client.id },
                   data: {
@@ -593,7 +488,6 @@ export async function processAutoRenewals() {
                   client.autoRenewTariff.name,
                   "balance",
                 );
-                // T-autorenew: кастомное EXPIRED уведомление — все попытки исчерпаны, автопродление выключено.
                 await dispatchAutoRenewNotification(client.id, "EXPIRED", {
                   tariffName: client.autoRenewTariff.name,
                   amount: renewBase.amount,
@@ -602,14 +496,6 @@ export async function processAutoRenewals() {
                   subIndex: 0,
                   balance: client.balance,
                 }).catch(() => {});
-                console.log(
-                  `[auto-renew] Client ${client.id} failed: all retries exhausted + grace period over. Auto-renew disabled.`,
-                );
-              } else {
-                // Still within grace period — keep trying each hour
-                console.log(
-                  `[auto-renew] Client ${client.id} retries exhausted but grace period active. Will keep checking.`,
-                );
               }
             }
           }
@@ -618,7 +504,6 @@ export async function processAutoRenewals() {
     } catch (e) {
       console.error(`[auto-renew] Error processing client ${client.id}:`, e);
 
-      // On unexpected error → use retry logic instead of instant disable
       const currentRetryCount = client.autoRenewRetryCount ?? 0;
       if (currentRetryCount < maxRetries) {
         await prisma.client
@@ -628,7 +513,6 @@ export async function processAutoRenewals() {
           })
           .catch((err) => console.error("[auto-renew] Failed to update retry count:", err));
       } else {
-        // Retries exhausted on errors too → disable
         await prisma.client
           .update({
             where: { id: client.id },
@@ -641,9 +525,8 @@ export async function processAutoRenewals() {
           .catch((err) => console.error("[auto-renew] Failed to disable auto-renew on error:", err));
 
         await notifyAutoRenewFailed(client.id, client.autoRenewTariff.name, "error").catch(() => {});
-        // T-autorenew: кастомное FAILED уведомление — runtime ошибка обработки.
         await dispatchAutoRenewNotification(client.id, "FAILED", {
-          tariffName: client.autoRenewTariff?.name ?? "—",
+          tariffName: client.autoRenewTariff?.name ?? "-",
           amount: 0,
           currency: client.autoRenewTariff?.currency ?? "RUB",
           subIndex: 0,
@@ -653,44 +536,26 @@ export async function processAutoRenewals() {
     }
   }
 
-  // обрабатываем индивидуальные автосписания secondary подписок.
   await processSecondaryAutoRenewals();
 }
 
-/**
- * автосписание для secondary подписок (per-sub).
- * Перебирает все secondary с auto_renew_enabled=true и за `daysBeforeExpiry` продлевает.
- *
- * Стратегия списания (mirror как у root):
- *   1. Сначала пытаемся полностью с баланса (атомарный debit).
- *   2. Если на балансе не хватает И включён YooKassa-recurring И есть saved card —
- *      списываем разницу с карты + остаток баланса (если есть). Сумма из карты = price - balance.
- *   3. Если ни баланс, ни YooKassa не сработали — пропускаем + лог.
- *
- * Защита:
- *   • Дедуп: если за последние 2 часа уже был PAID YooKassa autopay для этой sec — НЕ списываем повторно.
- *   • Activation fail после YK списания → баланс возвращаем, YooKassa деньги не возвращаем
- *     (но Payment остаётся PAID — на следующем cron tick попробуем активировать заново).
- *   • Notifications клиенту при успехе/ошибке (notifyAutoRenewYookassaSuccess/Failed).
- */
 async function processSecondaryAutoRenewals(): Promise<void> {
   const config = await getSystemConfig();
   const daysBeforeExpiry = config.autoRenewDaysBeforeExpiry ?? 1;
+  const gracePeriodDays = config.autoRenewGracePeriodDays ?? 2;
   const renewThreshold = daysBeforeExpiry * DAY_MS;
+  const gracePeriod = gracePeriodDays * DAY_MS;
   const now = Date.now();
 
-  // Полностью осиротевшие подписки: тариф удалён (tariffId=null) И fallback-тарифа нет.
-  // Продлевать не на что — раньше висели включёнными и молчали («не списывает и не пишет»).
-  // Выключаем тумблер и один раз говорим клиенту (EXPIRED-шаблон «автосписание отключено»).
   const orphans = await prisma.subscription.findMany({
     where: { autoRenewEnabled: true, tariffId: null, autoRenewTariffId: null },
     select: { id: true, ownerId: true, subscriptionIndex: true, owner: { select: { balance: true } } },
   });
   for (const o of orphans) {
     await prisma.subscription.update({ where: { id: o.id }, data: { autoRenewEnabled: false } }).catch(() => {});
-    console.warn(`[auto-renew/sec] sub ${o.id}: тариф удалён и fallback-тарифа нет — автосписание выключено, клиент уведомлён.`);
+    console.warn(`[auto-renew/sec] sub ${o.id}: тариф удален и fallback-тарифа нет - автосписание выключено.`);
     await dispatchAutoRenewNotification(o.ownerId, "EXPIRED", {
-      tariffName: "—",
+      tariffName: "-",
       amount: 0,
       currency: "RUB",
       subIndex: o.subscriptionIndex ?? 0,
@@ -698,23 +563,10 @@ async function processSecondaryAutoRenewals(): Promise<void> {
     }).catch(() => {});
   }
 
-  // цикл обрабатывает ВСЕ подписки с autoRenewEnabled,
-  // включая primary (subscriptionIndex=0). Раньше был фильтр `subscriptionIndex > 0` чтобы избежать
-  // дублирования с legacy циклом по `Client.autoRenewEnabled`. Но эндпоинт включения автопродления
-  // (`/api/client/subscription/:type/:id/auto-renew`) теперь пишет ТОЛЬКО в Subscription, не в
-  // Client → старый цикл по Client всё равно не сработает для primary, а новый его пропускал.
-  // Зазор закрыт: один цикл = все подписки.
-  //
-  // Дедупликация: если у клиента случайно есть И `Client.autoRenewEnabled=true` И
-  // `Subscription[0].autoRenewEnabled=true` (legacy backfill), defensive-фильтр в Client-цикле
-  // ниже пропустит primary через `existsPrimaryWithAutoRenew` чтобы не списать дважды.
   const secondaries = await prisma.subscription.findMany({
     where: {
       autoRenewEnabled: true,
       remnawaveUuid: { not: null },
-      // тариф подписки мог быть удалён (FK SetNull → tariffId=null). Раньше такие
-      // подписки МОЛЧА выпадали из автосписания навсегда («не списывает при балансе»).
-      // Фоллбэк: autoRenewTariffId (сохраняется при включении тумблера).
       OR: [{ tariffId: { not: null } }, { autoRenewTariffId: { not: null } }],
     },
     include: {
@@ -729,7 +581,6 @@ async function processSecondaryAutoRenewals(): Promise<void> {
           email: true,
           yookassaPaymentMethodId: true,
           yookassaPaymentMethodTitle: true,
-          // personal discount применяется к auto-renew.
           personalDiscountPercent: true,
         },
       },
@@ -738,21 +589,22 @@ async function processSecondaryAutoRenewals(): Promise<void> {
 
   for (const sec of secondaries) {
     if (!sec.remnawaveUuid || !sec.owner || sec.owner.isBlocked) continue;
-    // Тариф для продления: обычно sec.tariff; если тариф удалён (tariffId=null) —
-    // фоллбэк на autoRenewTariffId. Успешное продление восстановит sec.tariffId.
     let tariffForRenewal = sec.tariff;
     if (!tariffForRenewal && sec.autoRenewTariffId) {
       tariffForRenewal = await prisma.tariff.findUnique({ where: { id: sec.autoRenewTariffId } });
     }
     if (!tariffForRenewal) {
-      console.warn(`[auto-renew/sec] sub ${sec.id}: autoRenewEnabled, но тариф не найден (tariffId и autoRenewTariffId пусты либо тарифы удалены) — пропуск.`);
       continue;
     }
     try {
-      // 1. Проверяем срок подписки в Remna
       const remnaUser = await remnaGetUser(sec.remnawaveUuid);
       if (remnaUser.error) {
         console.warn(`[auto-renew/sec] Failed to fetch remna user ${sec.remnawaveUuid}:`, remnaUser.error);
+        // Отключаем автопродление для несуществующих / битых в Remnawave пользователей
+        await prisma.subscription.update({
+          where: { id: sec.id },
+          data: { autoRenewEnabled: false },
+        }).catch(() => {});
         continue;
       }
       const userData = (remnaUser.data as Record<string, unknown>)?.response ?? remnaUser.data;
@@ -762,27 +614,19 @@ async function processSecondaryAutoRenewals(): Promise<void> {
       if (Number.isNaN(expireAtDate.getTime())) continue;
       const timeLeft = expireAtDate.getTime() - now;
 
-      // T-autorenew: для UPCOMING шаблонов — отправляем напоминания заранее, до момента списания.
-      // Окно дёргаем при каждом проходе cron; dispatchAutoRenewNotification внутри сам сравнит
-      // minutesLeft с offsetMinutes шаблонов (±30 мин) и отправит только подходящие.
-      // расчёт цены автопродления с учётом
-      // доп. устройств (extraDevicesMonthlyPrice × коэф длительности) и личной скидки.
-      // Старый customPrice (legacy) используется только если extraDevices=0.
       const renewDurationDays = tariffForRenewal.durationDays || 30;
       const extrasMonthly = sec.extraDevicesMonthlyPrice ?? 0;
       const extrasForPeriod = extrasMonthly > 0
         ? Math.floor(extrasMonthly * (renewDurationDays / 30))
         : 0;
       const baseRenewPrice = extrasForPeriod > 0
-        ? tariffForRenewal.price  // если есть новые extras — берём базовую цену тарифа, к ней добавим extras
+        ? tariffForRenewal.price
         : (sec.customPrice && sec.customPrice > 0 ? sec.customPrice : tariffForRenewal.price);
       let priceBeforeDiscount = baseRenewPrice + extrasForPeriod;
       const pd = sec.owner.personalDiscountPercent ?? 0;
       const priceRaw = pd > 0
         ? Math.max(0, Math.floor(priceBeforeDiscount * (1 - pd / 100)))
         : priceBeforeDiscount;
-      // Округляем до копеек: customPrice/extras — Float, накопленная погрешность
-      // (199.999999… при «200» в UI) не должна ронять списание.
       const price = Math.round(priceRaw * 100) / 100;
 
       if (timeLeft > 0) {
@@ -799,14 +643,9 @@ async function processSecondaryAutoRenewals(): Promise<void> {
         }).catch(() => {});
       }
 
-      // Списываем только в окне [0..renewThreshold] (или до 7 дней просрочки).
       if (timeLeft > renewThreshold || timeLeft < -7 * DAY_MS) continue;
-
       if (price <= 0) continue;
 
-      // 3. Дедуп: проверяем не было ли успешного YK autopay для этой sec за последние 2 часа.
-      // Если был → значит карта уже списала, но activation мог не пройти.
-      // Просто пробуем активировать снова через тот payment (не списываем повторно).
       const recentYkPayment = await prisma.payment.findFirst({
         where: {
           clientId: sec.owner.id,
@@ -819,9 +658,8 @@ async function processSecondaryAutoRenewals(): Promise<void> {
         orderBy: { paidAt: "desc" },
       });
       if (recentYkPayment) {
-        console.log(`[auto-renew/sec] Found recent YK autopay ${recentYkPayment.id} for sec ${sec.id}, retrying activation only.`);
         const { extendSecondarySubscription } = await import("../tariff/tariff-activation.service.js");
-        const retryResult = await extendSecondarySubscription(
+        await extendSecondarySubscription(
           sec.id,
           {
             id: tariffForRenewal.id,
@@ -838,23 +676,15 @@ async function processSecondaryAutoRenewals(): Promise<void> {
           undefined,
           0,
         );
-        if (retryResult.ok) {
-          console.log(`[auto-renew/sec] sec ${sec.id} re-activated from recent YK payment ${recentYkPayment.id}.`);
-        } else {
-          console.error(`[auto-renew/sec] sec ${sec.id} retry activation STILL failing: ${retryResult.error}`);
-        }
         continue;
       }
 
-      // 4. Списание: balance-first, fallback YooKassa.
       const balanceForUser = sec.owner.balance ?? 0;
       let paidViaBalance = 0;
       let paidViaYookassa = 0;
       let yookassaPaymentId: string | null = null;
       let success = false;
 
-      // Phase A: полное списание с баланса (атомарный debit).
-      // ε=0.01: страховка от float-погрешности хранимого баланса (см. price выше).
       const balanceDebit = await prisma.client.updateMany({
         where: { id: sec.owner.id, balance: { gte: price - 0.01 } },
         data: { balance: { decrement: price } },
@@ -864,7 +694,6 @@ async function processSecondaryAutoRenewals(): Promise<void> {
         paidViaBalance = price;
         success = true;
       } else {
-        // Phase B: баланса не хватает. Проверяем YooKassa-recurring.
         const ykEnabled =
           config.yookassaRecurringEnabled === true &&
           !!sec.owner.yookassaPaymentMethodId &&
@@ -872,10 +701,32 @@ async function processSecondaryAutoRenewals(): Promise<void> {
           !!config.yookassaSecretKey?.trim();
 
         if (!ykEnabled) {
+          // Если льготный период истек - выключаем автосписание
+          const expiredSince = timeLeft < 0 ? Math.abs(timeLeft) : 0;
+          if (expiredSince >= gracePeriod) {
+            await prisma.subscription.update({
+              where: { id: sec.id },
+              data: { autoRenewEnabled: false },
+            }).catch(() => {});
+            console.log(`[auto-renew/sec] sec ${sec.id} failed: grace period over. Auto-renew disabled.`);
+            await dispatchAutoRenewNotification(sec.owner.id, "EXPIRED", {
+              tariffName: tariffForRenewal.name,
+              amount: price,
+              currency: tariffForRenewal.currency,
+              expireAt: expireAtDate,
+              subIndex: sec.subscriptionIndex,
+              balance: balanceForUser,
+            }).catch(() => {});
+            continue;
+          }
+
+          // Троттлинг: проверяем подписку с нулевым балансом не чаще 1 раза в час
+          const checkAllowed = await tryMarkSubDedup(sec.id, "sec_nobal_check", 60 * 60 * 1000);
+          if (!checkAllowed) {
+            continue;
+          }
+
           console.log(`[auto-renew/sec] Insufficient balance for sec ${sec.id} (need ${price}, have ${balanceForUser}); YK fallback disabled. Skipping.`);
-          // T-autorenew: кастомные FAILED уведомления (когда нет ни баланса, ни YK).
-          // Дедуп 24ч ОБЯЗАТЕЛЕН: cron ежеминутный, окно списания до 8 дней —
-          // без него юзер получал «списание не удалось» каждую минуту.
           await dispatchAutoRenewNotification(sec.owner.id, "FAILED", {
             tariffName: tariffForRenewal.name,
             amount: price,
@@ -888,14 +739,11 @@ async function processSecondaryAutoRenewals(): Promise<void> {
           continue;
         }
 
-        // Карту пробуем не чаще раза в час: ежеминутный cron иначе долбит
-        // отклонённую карту 60 раз/час (банки такое банят) + спамит уведомлениями.
         const ykAttemptAllowed = await tryMarkSubDedup(sec.id, "yk_attempt", 60 * 60 * 1000);
         if (!ykAttemptAllowed) {
           continue;
         }
 
-        // Дебитуем доступный баланс (если что-то есть), остаток добираем картой.
         const balancePortion = Math.min(Math.max(0, balanceForUser), price);
         const cardPortion = price - balancePortion;
 
@@ -909,10 +757,8 @@ async function processSecondaryAutoRenewals(): Promise<void> {
           }
         }
 
-        // YooKassa autopay для cardPortion.
         try {
           const orderIdForYk = randomUUID();
-          // добавили tg:<id> в description (см. /yookassa/create-payment).
           const tgIdSuffix = sec.owner.telegramId ? ` tg:${sec.owner.telegramId}` : "";
           const autopayResult = await createYookassaAutopayment({
             shopId: config.yookassaShopId!.trim(),
@@ -936,7 +782,6 @@ async function processSecondaryAutoRenewals(): Promise<void> {
             yookassaPaymentId = autopayResult.paymentId;
             success = true;
           } else {
-            // YK отказала — возвращаем частично списанный баланс.
             if (paidViaBalance > 0) {
               await prisma.client.update({
                 where: { id: sec.owner.id },
@@ -945,7 +790,6 @@ async function processSecondaryAutoRenewals(): Promise<void> {
               paidViaBalance = 0;
             }
             console.error(`[auto-renew/sec] YK autopay failed for sec ${sec.id}: ${autopayResult.error}`);
-            // Уведомляем об отказе карты не чаще раза в сутки (попытки — раз в час).
             const ykFailNoticeAllowed = await tryMarkSubDedup(sec.id, "yk_fail_notice", 24 * 60 * 60 * 1000);
             if (ykFailNoticeAllowed) {
               await notifyAutoRenewYookassaFailed(sec.owner.id, tariffForRenewal.name, autopayResult.error).catch(() => {});
@@ -962,7 +806,6 @@ async function processSecondaryAutoRenewals(): Promise<void> {
             continue;
           }
         } catch (e) {
-          // Сетевая / runtime ошибка YooKassa — возвращаем баланс.
           if (paidViaBalance > 0) {
             await prisma.client.update({
               where: { id: sec.owner.id },
@@ -982,8 +825,6 @@ async function processSecondaryAutoRenewals(): Promise<void> {
 
       if (!success) continue;
 
-      // 5. Деньги списаны. Записываем Payment ПЕРЕД активацией (для дедупа на следующем тике
-      // если activation fail — payment останется, recentYkPayment его найдёт).
       const payment = await prisma.payment.create({
         data: {
           clientId: sec.owner.id,
@@ -1007,7 +848,6 @@ async function processSecondaryAutoRenewals(): Promise<void> {
         return null;
       });
 
-      // 6. Активация подписки.
       const { extendSecondarySubscription } = await import("../tariff/tariff-activation.service.js");
       const result = await extendSecondarySubscription(
         sec.id,
@@ -1028,27 +868,21 @@ async function processSecondaryAutoRenewals(): Promise<void> {
       );
 
       if (!result.ok) {
-        // Activation fail.
-        // Баланс возвращаем (если списали).
         if (paidViaBalance > 0) {
           await prisma.client.update({
             where: { id: sec.owner.id },
             data: { balance: { increment: paidViaBalance } },
           }).catch(() => {});
         }
-        // YK-деньги — НЕ возвращаем, оставляем Payment PAID, на след. cron tick
-        // recentYkPayment его найдёт и попробует только активацию (без списания).
         if (payment && paidViaYookassa > 0) {
-          console.error(`[auto-renew/sec] sec ${sec.id} extend FAILED, YK paid ${paidViaYookassa} kept — will retry activation on next cron.`);
+          console.error(`[auto-renew/sec] sec ${sec.id} extend FAILED, YK paid ${paidViaYookassa} kept.`);
         } else if (payment) {
-          // Чистый balance-payment без YK — можем смело пометить FAILED.
           await prisma.payment.update({ where: { id: payment.id }, data: { status: "FAILED" } }).catch(() => {});
         }
         console.error(`[auto-renew/sec] Failed to extend sec ${sec.id}: ${result.error}`);
         continue;
       }
 
-      // 7. Success → notif клиенту.
       if (paidViaYookassa > 0) {
         await notifyAutoRenewYookassaSuccess(
           sec.owner.id,
@@ -1060,7 +894,6 @@ async function processSecondaryAutoRenewals(): Promise<void> {
           paidViaYookassa,
         ).catch(() => {});
       }
-      // T-autorenew: кастомные SUCCESS уведомления.
       await dispatchAutoRenewNotification(sec.owner.id, "SUCCESS", {
         tariffName: tariffForRenewal.name,
         amount: price,
@@ -1070,7 +903,7 @@ async function processSecondaryAutoRenewals(): Promise<void> {
         balance: Math.max(0, (sec.owner.balance ?? 0) - paidViaBalance),
       }).catch(() => {});
 
-      console.log(`[auto-renew/sec] Renewed sec ${sec.id} for client ${sec.owner.id} — balance:${paidViaBalance}, yk:${paidViaYookassa}, total:${price}`);
+      console.log(`[auto-renew/sec] Renewed sec ${sec.id} for client ${sec.owner.id}`);
     } catch (e) {
       console.error(`[auto-renew/sec] Unexpected error processing sec ${sec.id}:`, e);
     }

--- a/backend/src/modules/payment/auto-renew.cron.ts
+++ b/backend/src/modules/payment/auto-renew.cron.ts
@@ -236,12 +236,6 @@ export async function processAutoRenewals() {
 
       // Фаза 2: Попытка продления
       if (timeLeft <= renewThreshold && timeLeft >= -gracePeriod) {
-        // Троттлинг: не пытаемся проводить списание чаще 1 раза в час
-        const attemptAllowed = await tryMarkSubDedup(client.id, "client_renew_attempt", 60 * 60 * 1000);
-        if (!attemptAllowed) {
-          continue;
-        }
-
         const baseTariffPrice = renewBase.amount;
         const personalPct = typeof client.personalDiscountPercent === "number" && client.personalDiscountPercent > 0
           ? Math.min(100, client.personalDiscountPercent)

--- a/backend/src/modules/payment/auto-renew.cron.ts
+++ b/backend/src/modules/payment/auto-renew.cron.ts
@@ -6,9 +6,37 @@ import { remnaGetUser, isRemnaConfigured } from "../remna/remna.client.js";
 import { getSystemConfig } from "../client/client.service.js";
 import { createYookassaAutopayment } from "../yookassa/yookassa.service.js";
 import { applyPercent } from "../client/personal-discount.js";
+import {
+  notifyAutoRenewSuccess,
+  notifyAutoRenewFailed,
+  notifyAutoRenewUpcoming,
+  notifyAutoRenewRetry,
+  notifyAutoRenewYookassaSuccess,
+  notifyAutoRenewYookassaFailed,
+  notifyAdminsAboutAutoRenewFailed,
+} from "../notification/telegram-notify.service.js";
+import { dispatchAutoRenewNotification, tryMarkSubDedup } from "../notification/auto-renew-notifications.service.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 /**
- * Считает базовую сумму автопродления для клиента: priceOption.price + extras * pricePerExtra * scaling * discount.
+ * Проверка на неустранимые ошибки Remnawave.
+ * Если пользователя нет в базе панели или UUID поврежден, ретраить бессмысленно.
+ */
+function isFatalRemnaError(error: unknown): boolean {
+  const s = String(error).toLowerCase();
+  return (
+    s.includes("validation") ||
+    s.includes("not found") ||
+    s.includes("404") ||
+    s.includes("does not exist") ||
+    s.includes("invalid uuid") ||
+    s.includes("bad request")
+  );
+}
+
+/**
+ * Расчет базовой стоимости автопродления для клиента.
  */
 async function computeAutoRenewBaseAmount(client: {
   id: string;
@@ -45,17 +73,9 @@ async function computeAutoRenewBaseAmount(client: {
   };
 }
 
-import {
-  notifyAutoRenewSuccess,
-  notifyAutoRenewFailed,
-  notifyAutoRenewUpcoming,
-  notifyAutoRenewRetry,
-  notifyAutoRenewYookassaSuccess,
-  notifyAutoRenewYookassaFailed,
-  notifyAdminsAboutAutoRenewFailed,
-} from "../notification/telegram-notify.service.js";
-import { dispatchAutoRenewNotification, tryMarkSubDedup } from "../notification/auto-renew-notifications.service.js";
-
+/**
+ * Валидация и применение промокода для автопродления.
+ */
 async function tryApplyPromoForAutoRenew(
   clientId: string,
   code: string | null,
@@ -90,6 +110,9 @@ async function tryApplyPromoForAutoRenew(
   return { finalPrice, promoCodeId: promo.id };
 }
 
+/**
+ * Планировщик автопродления. Запуск раз в минуту для точности UPCOMING-уведомлений.
+ */
 export function startAutoRenewScheduler() {
   cron.schedule("* * * * *", async () => {
     try {
@@ -100,8 +123,9 @@ export function startAutoRenewScheduler() {
   });
 }
 
-const DAY_MS = 24 * 60 * 60 * 1000;
-
+/**
+ * Обработка автопродления основных клиентов (legacy cycle).
+ */
 export async function processAutoRenewals() {
   if (!isRemnaConfigured()) {
     console.warn("[auto-renew] Remna is not configured. Skipping.");
@@ -133,6 +157,7 @@ export async function processAutoRenewals() {
   for (const client of clients) {
     if (!client.remnawaveUuid || !client.autoRenewTariff) continue;
 
+    // Дедуп: если subscription[0] управляется новым циклом подписок, пропускаем клиентский цикл
     const primaryHasAutoRenew = await prisma.subscription.findUnique({
       where: { ownerId_subscriptionIndex: { ownerId: client.id, subscriptionIndex: 0 } },
       select: { autoRenewEnabled: true },
@@ -144,13 +169,16 @@ export async function processAutoRenewals() {
     try {
       const remnaUser = await remnaGetUser(client.remnawaveUuid);
       if (remnaUser.error) {
-        console.error(`[auto-renew] Failed to fetch remna user ${client.remnawaveUuid}:`, remnaUser.error);
         const errStr = String(remnaUser.error);
-        if (errStr.includes("Validation") || errStr.includes("not found") || errStr.includes("404")) {
+        console.error(`[auto-renew] Failed to fetch remna user ${client.remnawaveUuid}:`, errStr);
+
+        // Фатальная ошибка: выключаем автосписание, чтобы не спамить Remnawave каждую минуту
+        if (isFatalRemnaError(errStr)) {
           await prisma.client.update({
             where: { id: client.id },
-            data: { autoRenewEnabled: false },
+            data: { autoRenewEnabled: false, autoRenewRetryCount: 0 },
           }).catch(() => {});
+          console.warn(`[auto-renew] Client ${client.id}: пользователь не найден в Remnawave. Автопродление отключено.`);
         }
         continue;
       }
@@ -166,6 +194,7 @@ export async function processAutoRenewals() {
       const timeLeft = expireAtDate.getTime() - now;
       const renewBase = await computeAutoRenewBaseAmount(client);
 
+      // Фаза 1: Уведомление о скором списании
       if (timeLeft > 0 && timeLeft <= notifyThreshold) {
         const shouldNotify =
           !client.autoRenewNotifiedAt ||
@@ -191,6 +220,7 @@ export async function processAutoRenewals() {
         }
       }
 
+      // Кастомные UPCOMING уведомления из конструктора
       if (timeLeft > 0) {
         await dispatchAutoRenewNotification(client.id, "UPCOMING", {
           tariffName: client.autoRenewTariff.name,
@@ -204,7 +234,14 @@ export async function processAutoRenewals() {
         }).catch(() => {});
       }
 
-      if (timeLeft <= renewThreshold && timeLeft >= -(3 * DAY_MS)) {
+      // Фаза 2: Попытка продления
+      if (timeLeft <= renewThreshold && timeLeft >= -gracePeriod) {
+        // Троттлинг: не пытаемся проводить списание чаще 1 раза в час
+        const attemptAllowed = await tryMarkSubDedup(client.id, "client_renew_attempt", 60 * 60 * 1000);
+        if (!attemptAllowed) {
+          continue;
+        }
+
         const baseTariffPrice = renewBase.amount;
         const personalPct = typeof client.personalDiscountPercent === "number" && client.personalDiscountPercent > 0
           ? Math.min(100, client.personalDiscountPercent)
@@ -314,6 +351,7 @@ export async function processAutoRenewals() {
             balance: Math.max(0, client.balance - tariffPrice),
           }).catch(() => {});
         } else {
+          // Недостаточно баланса: пробуем автоплатеж ЮKassa
           let yookassaPaid = false;
 
           if (
@@ -460,7 +498,7 @@ export async function processAutoRenewals() {
               const newRetryCount = currentRetryCount + 1;
               await prisma.client.update({
                 where: { id: client.id },
-                data: { autoRenewRetryCount: newRetryCount },
+                data: { autoRenewRetryCount: newRetryCount, autoRenewNotifiedAt: new Date() },
               });
 
               await notifyAutoRenewRetry(
@@ -539,14 +577,20 @@ export async function processAutoRenewals() {
   await processSecondaryAutoRenewals();
 }
 
+/**
+ * Обработка автопродления вторичных и объединенных подписок (Subscription table).
+ */
 async function processSecondaryAutoRenewals(): Promise<void> {
   const config = await getSystemConfig();
   const daysBeforeExpiry = config.autoRenewDaysBeforeExpiry ?? 1;
   const gracePeriodDays = config.autoRenewGracePeriodDays ?? 2;
+  const maxRetries = config.autoRenewMaxRetries ?? 3;
+
   const renewThreshold = daysBeforeExpiry * DAY_MS;
   const gracePeriod = gracePeriodDays * DAY_MS;
   const now = Date.now();
 
+  // Очистка подписок с удаленными тарифами
   const orphans = await prisma.subscription.findMany({
     where: { autoRenewEnabled: true, tariffId: null, autoRenewTariffId: null },
     select: { id: true, ownerId: true, subscriptionIndex: true, owner: { select: { balance: true } } },
@@ -589,6 +633,7 @@ async function processSecondaryAutoRenewals(): Promise<void> {
 
   for (const sec of secondaries) {
     if (!sec.remnawaveUuid || !sec.owner || sec.owner.isBlocked) continue;
+
     let tariffForRenewal = sec.tariff;
     if (!tariffForRenewal && sec.autoRenewTariffId) {
       tariffForRenewal = await prisma.tariff.findUnique({ where: { id: sec.autoRenewTariffId } });
@@ -596,20 +641,28 @@ async function processSecondaryAutoRenewals(): Promise<void> {
     if (!tariffForRenewal) {
       continue;
     }
+
     try {
       const remnaUser = await remnaGetUser(sec.remnawaveUuid);
       if (remnaUser.error) {
-        console.warn(`[auto-renew/sec] Failed to fetch remna user ${sec.remnawaveUuid}:`, remnaUser.error);
-        // Отключаем автопродление для несуществующих / битых в Remnawave пользователей
-        await prisma.subscription.update({
-          where: { id: sec.id },
-          data: { autoRenewEnabled: false },
-        }).catch(() => {});
+        const errStr = String(remnaUser.error);
+        console.warn(`[auto-renew/sec] Failed to fetch remna user ${sec.remnawaveUuid}:`, errStr);
+
+        // Отключаем автопродление только при фатальных ошибках Remnawave
+        if (isFatalRemnaError(errStr)) {
+          await prisma.subscription.update({
+            where: { id: sec.id },
+            data: { autoRenewEnabled: false, autoRenewRetryCount: 0 },
+          }).catch(() => {});
+          console.warn(`[auto-renew/sec] sub ${sec.id}: пользователь не найден в Remnawave. Автосписание выключено.`);
+        }
         continue;
       }
+
       const userData = (remnaUser.data as Record<string, unknown>)?.response ?? remnaUser.data;
       const expireAtRaw = (userData as Record<string, unknown> | null)?.expireAt;
       if (!expireAtRaw) continue;
+
       const expireAtDate = new Date(expireAtRaw as string);
       if (Number.isNaN(expireAtDate.getTime())) continue;
       const timeLeft = expireAtDate.getTime() - now;
@@ -629,6 +682,7 @@ async function processSecondaryAutoRenewals(): Promise<void> {
         : priceBeforeDiscount;
       const price = Math.round(priceRaw * 100) / 100;
 
+      // UPCOMING уведомления отправляются раз в минуту через встроенный dedup
       if (timeLeft > 0) {
         const minutesLeft = Math.round(timeLeft / 60000);
         await dispatchAutoRenewNotification(sec.owner.id, "UPCOMING", {
@@ -643,9 +697,17 @@ async function processSecondaryAutoRenewals(): Promise<void> {
         }).catch(() => {});
       }
 
-      if (timeLeft > renewThreshold || timeLeft < -7 * DAY_MS) continue;
+      // Списываем только при приближении к порогу и до окончания льготного периода
+      if (timeLeft > renewThreshold || timeLeft < -gracePeriod) continue;
       if (price <= 0) continue;
 
+      // Троттлинг попыток списания: не чаще одного раза в 60 минут на одну подписку
+      const attemptAllowed = await tryMarkSubDedup(sec.id, "sec_renew_attempt", 60 * 60 * 1000);
+      if (!attemptAllowed) {
+        continue;
+      }
+
+      // Дедуп платежа ЮKassa за последние 2 часа
       const recentYkPayment = await prisma.payment.findFirst({
         where: {
           clientId: sec.owner.id,
@@ -657,9 +719,10 @@ async function processSecondaryAutoRenewals(): Promise<void> {
         },
         orderBy: { paidAt: "desc" },
       });
+
       if (recentYkPayment) {
         const { extendSecondarySubscription } = await import("../tariff/tariff-activation.service.js");
-        await extendSecondarySubscription(
+        const retryResult = await extendSecondarySubscription(
           sec.id,
           {
             id: tariffForRenewal.id,
@@ -676,6 +739,12 @@ async function processSecondaryAutoRenewals(): Promise<void> {
           undefined,
           0,
         );
+        if (retryResult.ok) {
+          await prisma.subscription.update({
+            where: { id: sec.id },
+            data: { autoRenewRetryCount: 0, autoRenewNotifiedAt: null },
+          }).catch(() => {});
+        }
         continue;
       }
 
@@ -685,6 +754,7 @@ async function processSecondaryAutoRenewals(): Promise<void> {
       let yookassaPaymentId: string | null = null;
       let success = false;
 
+      // Фаза А: списание с баланса
       const balanceDebit = await prisma.client.updateMany({
         where: { id: sec.owner.id, balance: { gte: price - 0.01 } },
         data: { balance: { decrement: price } },
@@ -694,39 +764,104 @@ async function processSecondaryAutoRenewals(): Promise<void> {
         paidViaBalance = price;
         success = true;
       } else {
+        // Фаза Б: fallback на рекуррент ЮKassa
         const ykEnabled =
           config.yookassaRecurringEnabled === true &&
           !!sec.owner.yookassaPaymentMethodId &&
           !!config.yookassaShopId?.trim() &&
           !!config.yookassaSecretKey?.trim();
 
-        if (!ykEnabled) {
-          // Если льготный период истек - выключаем автосписание
-          const expiredSince = timeLeft < 0 ? Math.abs(timeLeft) : 0;
-          if (expiredSince >= gracePeriod) {
-            await prisma.subscription.update({
-              where: { id: sec.id },
-              data: { autoRenewEnabled: false },
-            }).catch(() => {});
-            console.log(`[auto-renew/sec] sec ${sec.id} failed: grace period over. Auto-renew disabled.`);
-            await dispatchAutoRenewNotification(sec.owner.id, "EXPIRED", {
-              tariffName: tariffForRenewal.name,
-              amount: price,
-              currency: tariffForRenewal.currency,
-              expireAt: expireAtDate,
-              subIndex: sec.subscriptionIndex,
-              balance: balanceForUser,
-            }).catch(() => {});
-            continue;
-          }
+        if (ykEnabled) {
+          const ykAttemptAllowed = await tryMarkSubDedup(sec.id, "yk_attempt", 60 * 60 * 1000);
+          if (ykAttemptAllowed) {
+            const balancePortion = Math.min(Math.max(0, balanceForUser), price);
+            const cardPortion = price - balancePortion;
 
-          // Троттлинг: проверяем подписку с нулевым балансом не чаще 1 раза в час
-          const checkAllowed = await tryMarkSubDedup(sec.id, "sec_nobal_check", 60 * 60 * 1000);
-          if (!checkAllowed) {
-            continue;
-          }
+            if (balancePortion > 0) {
+              const partialDebit = await prisma.client.updateMany({
+                where: { id: sec.owner.id, balance: { gte: balancePortion } },
+                data: { balance: { decrement: balancePortion } },
+              });
+              if (partialDebit.count > 0) {
+                paidViaBalance = balancePortion;
+              }
+            }
 
-          console.log(`[auto-renew/sec] Insufficient balance for sec ${sec.id} (need ${price}, have ${balanceForUser}); YK fallback disabled. Skipping.`);
+            try {
+              const orderIdForYk = randomUUID();
+              const tgIdSuffix = sec.owner.telegramId ? ` tg:${sec.owner.telegramId}` : "";
+              const autopayResult = await createYookassaAutopayment({
+                shopId: config.yookassaShopId!.trim(),
+                secretKey: config.yookassaSecretKey!.trim(),
+                amount: cardPortion,
+                currency: tariffForRenewal.currency.toUpperCase(),
+                paymentMethodId: sec.owner.yookassaPaymentMethodId!,
+                description: `Автопродление #${sec.subscriptionIndex} (${tariffForRenewal.name})${tgIdSuffix}`,
+                metadata: {
+                  orderId: orderIdForYk,
+                  extendsSecondarySubId: sec.id,
+                  autoRenew: "true",
+                  clientId: sec.owner.id,
+                },
+                customerEmail: sec.owner.email,
+                customerTelegramUsername: sec.owner.telegramUsername ?? null,
+              });
+
+              if (autopayResult.ok) {
+                paidViaYookassa = cardPortion;
+                yookassaPaymentId = autopayResult.paymentId;
+                success = true;
+              } else {
+                if (paidViaBalance > 0) {
+                  await prisma.client.update({
+                    where: { id: sec.owner.id },
+                    data: { balance: { increment: paidViaBalance } },
+                  }).catch(() => {});
+                  paidViaBalance = 0;
+                }
+                console.error(`[auto-renew/sec] YK autopay failed for sec ${sec.id}: ${autopayResult.error}`);
+                const ykFailNoticeAllowed = await tryMarkSubDedup(sec.id, "yk_fail_notice", 24 * 60 * 60 * 1000);
+                if (ykFailNoticeAllowed) {
+                  await notifyAutoRenewYookassaFailed(sec.owner.id, tariffForRenewal.name, autopayResult.error).catch(() => {});
+                }
+              }
+            } catch (e) {
+              if (paidViaBalance > 0) {
+                await prisma.client.update({
+                  where: { id: sec.owner.id },
+                  data: { balance: { increment: paidViaBalance } },
+                }).catch(() => {});
+                paidViaBalance = 0;
+              }
+              console.error(`[auto-renew/sec] YK exception for sec ${sec.id}:`, e);
+            }
+          }
+        }
+      }
+
+      // Если оплата не удалась ни балансом, ни картой - запускаем цикл ретраев
+      if (!success) {
+        const currentRetryCount = sec.autoRenewRetryCount ?? 0;
+
+        if (currentRetryCount < maxRetries) {
+          const newRetryCount = currentRetryCount + 1;
+          await prisma.subscription.update({
+            where: { id: sec.id },
+            data: {
+              autoRenewRetryCount: newRetryCount,
+              autoRenewNotifiedAt: new Date(),
+            },
+          }).catch(() => {});
+
+          await notifyAutoRenewRetry(
+            sec.owner.id,
+            tariffForRenewal.name,
+            price,
+            tariffForRenewal.currency,
+            newRetryCount,
+            maxRetries,
+          ).catch(() => {});
+
           await dispatchAutoRenewNotification(sec.owner.id, "FAILED", {
             tariffName: tariffForRenewal.name,
             amount: price,
@@ -736,95 +871,39 @@ async function processSecondaryAutoRenewals(): Promise<void> {
             balance: balanceForUser,
             dedupKeyForSec: { secondarySubscriptionId: sec.id, ttlMs: 24 * 60 * 60 * 1000 },
           }).catch(() => {});
-          continue;
-        }
 
-        const ykAttemptAllowed = await tryMarkSubDedup(sec.id, "yk_attempt", 60 * 60 * 1000);
-        if (!ykAttemptAllowed) {
-          continue;
-        }
+          console.log(`[auto-renew/sec] sub ${sec.id} insufficient balance. Retry ${newRetryCount}/${maxRetries}.`);
+        } else {
+          const expiredSince = timeLeft < 0 ? Math.abs(timeLeft) : 0;
 
-        const balancePortion = Math.min(Math.max(0, balanceForUser), price);
-        const cardPortion = price - balancePortion;
+          if (expiredSince >= gracePeriod) {
+            await prisma.subscription.update({
+              where: { id: sec.id },
+              data: {
+                autoRenewEnabled: false,
+                autoRenewRetryCount: 0,
+                autoRenewNotifiedAt: null,
+              },
+            }).catch(() => {});
 
-        if (balancePortion > 0) {
-          const partialDebit = await prisma.client.updateMany({
-            where: { id: sec.owner.id, balance: { gte: balancePortion } },
-            data: { balance: { decrement: balancePortion } },
-          });
-          if (partialDebit.count > 0) {
-            paidViaBalance = balancePortion;
-          }
-        }
+            await notifyAutoRenewFailed(sec.owner.id, tariffForRenewal.name, "balance").catch(() => {});
 
-        try {
-          const orderIdForYk = randomUUID();
-          const tgIdSuffix = sec.owner.telegramId ? ` tg:${sec.owner.telegramId}` : "";
-          const autopayResult = await createYookassaAutopayment({
-            shopId: config.yookassaShopId!.trim(),
-            secretKey: config.yookassaSecretKey!.trim(),
-            amount: cardPortion,
-            currency: tariffForRenewal.currency.toUpperCase(),
-            paymentMethodId: sec.owner.yookassaPaymentMethodId!,
-            description: `Автопродление #${sec.subscriptionIndex} (${tariffForRenewal.name})${tgIdSuffix}`,
-            metadata: {
-              orderId: orderIdForYk,
-              extendsSecondarySubId: sec.id,
-              autoRenew: "true",
-              clientId: sec.owner.id,
-            },
-            customerEmail: sec.owner.email,
-            customerTelegramUsername: sec.owner.telegramUsername ?? null,
-          });
-
-          if (autopayResult.ok) {
-            paidViaYookassa = cardPortion;
-            yookassaPaymentId = autopayResult.paymentId;
-            success = true;
-          } else {
-            if (paidViaBalance > 0) {
-              await prisma.client.update({
-                where: { id: sec.owner.id },
-                data: { balance: { increment: paidViaBalance } },
-              }).catch(() => {});
-              paidViaBalance = 0;
-            }
-            console.error(`[auto-renew/sec] YK autopay failed for sec ${sec.id}: ${autopayResult.error}`);
-            const ykFailNoticeAllowed = await tryMarkSubDedup(sec.id, "yk_fail_notice", 24 * 60 * 60 * 1000);
-            if (ykFailNoticeAllowed) {
-              await notifyAutoRenewYookassaFailed(sec.owner.id, tariffForRenewal.name, autopayResult.error).catch(() => {});
-            }
-            await dispatchAutoRenewNotification(sec.owner.id, "FAILED", {
+            await dispatchAutoRenewNotification(sec.owner.id, "EXPIRED", {
               tariffName: tariffForRenewal.name,
               amount: price,
               currency: tariffForRenewal.currency,
               expireAt: expireAtDate,
               subIndex: sec.subscriptionIndex,
-              balance: sec.owner.balance ?? 0,
-              dedupKeyForSec: { secondarySubscriptionId: sec.id, ttlMs: 24 * 60 * 60 * 1000 },
+              balance: balanceForUser,
             }).catch(() => {});
-            continue;
+
+            console.log(`[auto-renew/sec] sub ${sec.id}: retries exhausted and grace period over. Auto-renew disabled.`);
           }
-        } catch (e) {
-          if (paidViaBalance > 0) {
-            await prisma.client.update({
-              where: { id: sec.owner.id },
-              data: { balance: { increment: paidViaBalance } },
-            }).catch(() => {});
-            paidViaBalance = 0;
-          }
-          const errMsg = e instanceof Error ? e.message : "unknown error";
-          console.error(`[auto-renew/sec] YK autopay exception for sec ${sec.id}:`, errMsg);
-          const ykExcNoticeAllowed = await tryMarkSubDedup(sec.id, "yk_fail_notice", 24 * 60 * 60 * 1000);
-          if (ykExcNoticeAllowed) {
-            await notifyAutoRenewYookassaFailed(sec.owner.id, tariffForRenewal.name, errMsg).catch(() => {});
-          }
-          continue;
         }
+        continue;
       }
 
-      if (!success) continue;
-
+      // Деньги списаны: фиксируем платеж в базе
       const payment = await prisma.payment.create({
         data: {
           clientId: sec.owner.id,
@@ -848,6 +927,7 @@ async function processSecondaryAutoRenewals(): Promise<void> {
         return null;
       });
 
+      // Активация продления в Remnawave
       const { extendSecondarySubscription } = await import("../tariff/tariff-activation.service.js");
       const result = await extendSecondarySubscription(
         sec.id,
@@ -883,6 +963,15 @@ async function processSecondaryAutoRenewals(): Promise<void> {
         continue;
       }
 
+      // Успех: сбрасываем счетчик ретраев
+      await prisma.subscription.update({
+        where: { id: sec.id },
+        data: {
+          autoRenewRetryCount: 0,
+          autoRenewNotifiedAt: null,
+        },
+      }).catch(() => {});
+
       if (paidViaYookassa > 0) {
         await notifyAutoRenewYookassaSuccess(
           sec.owner.id,
@@ -894,6 +983,7 @@ async function processSecondaryAutoRenewals(): Promise<void> {
           paidViaYookassa,
         ).catch(() => {});
       }
+
       await dispatchAutoRenewNotification(sec.owner.id, "SUCCESS", {
         tariffName: tariffForRenewal.name,
         amount: price,

--- a/bot/src/api.ts
+++ b/bot/src/api.ts
@@ -1,19 +1,23 @@
 /**
- * STEALTHNET 3.0 — API клиент бота (вызовы бэкенда).
+ * STEALTHNET 3.0 - API клиент бота (вызовы бэкенда).
  */
 
 const API_URL = (process.env.API_URL || "").replace(/\/$/, "");
 if (!API_URL) {
-  console.warn("API_URL not set in .env — bot API calls will fail");
+  console.warn("API_URL not set in .env - bot API calls will fail");
 }
+
+let cachedConfig: any = null;
+let configCacheTime = 0;
+
+let cachedTariffs: any = null;
+let tariffsCacheTime = 0;
+
+const CACHE_TTL = 60 * 1000; // Кэш на 60 секунд
 
 function getHeaders(token?: string): HeadersInit {
   const h: Record<string, string> = { "Content-Type": "application/json" };
   if (token) h["Authorization"] = `Bearer ${token}`;
-  // Идентифицируем все вызовы из бота через X-Telegram-Bot-Token, чтобы:
-  // 1) бэкенд знал какому клону принадлежит запрос (resolveBotForClientRequest)
-  // 2) IP-rate-limit'ы пропускали бот-трафик (skip-условие в app.ts).
-  // Без этого заголовка все регистрации через /start блокируются по IP бот-контейнера.
   const botToken = process.env.BOT_TOKEN || "";
   if (botToken) h["X-Telegram-Bot-Token"] = botToken;
   return h;
@@ -28,7 +32,6 @@ async function fetchJson<T>(path: string, opts?: { method?: string; body?: unkno
   const data = (await res.json().catch(() => ({}))) as T | { message?: string; code?: string };
   if (!res.ok) {
     const msg = typeof (data as { message?: string }).message === "string" ? (data as { message: string }).message : `HTTP ${res.status}`;
-    // T-tariff-restriction (портировано из WolfVPN): прокидываем code (напр. TARIFF_RESTRICTED) для бота.
     const err = new Error(msg) as Error & { code?: string };
     const code = (data as { code?: string }).code;
     if (typeof code === "string") err.code = code;
@@ -56,7 +59,7 @@ export async function linkTelegramFromBot(code: string, telegramId: number, tele
   return data as { message: string };
 }
 
-/** Подтверждение deep-link авторизации (бот → API) */
+/** Подтверждение deep-link авторизации (бот -> API) */
 export async function confirmTelegramAuth(token: string, telegramId: number, telegramUsername?: string): Promise<{ ok: boolean }> {
   const botToken = process.env.BOT_TOKEN || "";
   const res = await fetch(`${API_URL}/api/client/auth/telegram-login-confirm`, {
@@ -102,14 +105,12 @@ export async function getPublicConfig(): Promise<{
   serviceName?: string | null;
   logo?: string | null;
   logoBot?: string | null;
-  /** Telegram ID пользователей, которым показывается кнопка «Панель админа» в боте */
   botAdminTelegramIds?: string[] | null;
   publicAppUrl?: string | null;
   defaultCurrency?: string;
   trialEnabled?: boolean;
   trialDays?: number;
   plategaMethods?: { id: number; label: string }[];
-  /** кастомные названия и порядок платёжных провайдеров из админки. */
   paymentProviders?: { id: string; label: string; sortOrder: number }[];
   yoomoneyEnabled?: boolean;
   yookassaEnabled?: boolean;
@@ -123,13 +124,9 @@ export async function getPublicConfig(): Promise<{
   botWelcomeImage?: string | null;
   botWelcomeShowOnce?: boolean;
   botButtons?: { id: string; visible: boolean; label: string; order: number; style?: string; iconCustomEmojiId?: string; onePerRow?: boolean; emojiKey?: string }[] | null;
-  /** Кнопок в ряд в главном меню: 1 или 2 */
   botButtonsPerRow?: 1 | 2;
-  /** Тексты меню с уже подставленными эмодзи ({{BALANCE}} → unicode из bot_emojis) */
   resolvedBotMenuTexts?: Record<string, string>;
-  /** Для каких ключей текста меню в начале стоит премиум-эмодзи: key → custom_emoji_id (для entities) */
   menuTextCustomEmojiIds?: Record<string, string>;
-  /** Эмодзи по ключам: unicode и tgEmojiId (премиум) — для кнопок и подстановки в текст */
   botEmojis?: Record<string, { unicode?: string; tgEmojiId?: string }>;
   botBackLabel?: string | null;
   botMenuTexts?: Record<string, string> | null;
@@ -147,52 +144,33 @@ export async function getPublicConfig(): Promise<{
   agreementLink?: string | null;
   offerLink?: string | null;
   instructionsLink?: string | null;
-  // T11+T13+T14 (11.05.2026) — кастомизация бота
   refundLink?: string | null;
   supportHoursFrom?: string | null;
   supportHoursTo?: string | null;
   tgProxyText?: string | null;
   tgProxyUrlPrimary?: string | null;
   tgProxyUrlBackup?: string | null;
-  // динамический список прокси-серверов для бота.
   tgProxyServers?: { flag: string; name: string; url: string }[];
   reissueWarningText?: string | null;
   installSecondDeviceText?: string | null;
   helpIntroText?: string | null;
   giftIntroText?: string | null;
-  /** редактируемый текст шапки «📱 Мои устройства». */
   botDevicesText?: string | null;
-  /** подсказка «если инструкция не открылась». */
   botInstructionFallbackText?: string | null;
-  /** редактируемый текст экрана «📦 Дополнительные опции». */
   botExtraOptionsText?: string | null;
-  /** приписка под ссылкой подписки при активации подарка. */
   botGiftUrlNote?: string | null;
-  /** подсказка внизу экрана «💼 Мой баланс». */
   botBalanceText?: string | null;
-  /** текст экрана «💳 Пополнить баланс». */
   botTopupText?: string | null;
-  /** рефералка: строка под заголовком. */
   botReferralIntroText?: string | null;
-  /** рефералка: подсказка «💡 …» внизу экрана. */
   botReferralFooterText?: string | null;
-  /** текст шаринга реферальной ссылки (кнопка «📢 Поделиться»). */
   botReferralShareText?: string | null;
-  /** заголовок экрана выбора пробной подписки. */
   botTrialText?: string | null;
-  /** сообщение «все триалы использованы». */
   botTrialUsedText?: string | null;
-  /** экран выбора тарифа для подарка. */
   botGiftBuyText?: string | null;
-  /** приглашение ввести промокод. */
   botPromocodeText?: string | null;
-  /** показывать кнопку «➕ Докупить устройство» на экране Тарифов (default true). */
   botTariffsShowExtraDevicesButton?: boolean;
-  /** показывать кнопку «💼 Мой баланс» на экране Тарифов (default true). */
   botTariffsShowBalanceButton?: boolean;
-  /** показывать меню выбора категорий перед списком тарифов (default true). */
   botShowTariffCategories?: boolean;
-  /** заявки на вывод реф. баланса: вкл/выкл + мин. сумма. */
   withdrawalsEnabled?: boolean;
   withdrawalMinAmount?: number;
   videoInstructionsEnabled?: boolean;
@@ -212,26 +190,28 @@ export async function getPublicConfig(): Promise<{
   proxyUrl?: string | null;
   proxyTelegram?: boolean;
   proxyPayments?: boolean;
-  /** Авто-удаление нераспознанных сообщений (стикеры, случайный текст и т.п.) */
   botAutoDeleteUnknownMessages?: boolean;
-  /** Кастомный информационный блок (главное меню бота + кабинет). Пустая строка = скрыто. */
   botInfoBlock?: string | null;
   giftSubscriptionsEnabled?: boolean;
   defaultLanguage?: string;
   translations?: Record<string, Record<string, unknown>>;
 } | null> {
+  const now = Date.now();
+  if (cachedConfig && now - configCacheTime < CACHE_TTL) {
+    return cachedConfig;
+  }
+
   const cfg = await fetchJson<{
     paymentProviders?: { id: string; label: string; sortOrder: number }[];
   } | null>("/api/public/config");
-  // синхронизируем кастомные названия платёжек с keyboard.ts —
-  // module-level state используется во всех функциях кнопок выбора оплаты.
+
   try {
     const { setProviderLabels } = await import("./keyboard.js");
     setProviderLabels(cfg?.paymentProviders ?? null);
-  } catch {
-    // Если динамический импорт упал — кнопки используют дефолтные хардкоды.
-  }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch {}
+
+  cachedConfig = cfg;
+  configCacheTime = now;
   return cfg as any;
 }
 
@@ -278,16 +258,10 @@ export async function getMe(token: string): Promise<{
   referralPercent?: number | null;
   trialUsed?: boolean;
   autoRenewEnabled?: boolean;
-  // нужны для category-aware диалога в pay_tariff handler.
-  // currentTariffId/currentTariff может быть null если у клиента ещё нет основной подписки.
   currentTariffId?: string | null;
   currentTariff?: { id: string; name: string; categoryId: string | null } | null;
-  // для предупреждения юзера при включении автосписания
-  // что есть YooKassa-recurring fallback с сохранённой карты.
   yookassaPaymentMethodTitle?: string | null;
-  // персональная скидка клиента (%)
   personalDiscountPercent?: number | null;
-  // для 54-ФЗ-чека: подставляем сохранённый email в receipt prompt.
   email?: string | null;
 }> {
   return fetchJson("/api/client/auth/me", { token });
@@ -306,10 +280,7 @@ export async function getSubscriptionByUuid(
   return fetchJson("/api/client/subscription/by-uuid/" + encodeURIComponent(uuid), { token });
 }
 
-/**
- * доступные клиенту триалы (которые он ещё не активировал).
- * Если массив пустой — кнопка «🎁 Получить пробную» в главном меню скрывается.
- */
+/** доступные клиенту триалы */
 export async function getAvailableTrials(token: string): Promise<{
   items: { id: string; name: string; tariffId: string; tariffName: string | null; durationDays: number; description: string | null; sortOrder: number }[];
   hasAnyEnabled: boolean;
@@ -359,7 +330,7 @@ export async function getReferralStats(token: string): Promise<{
   return fetchJson("/api/client/referral-stats", { token });
 }
 
-/** T15: активация конкретного триала по ID. */
+/** активация конкретного триала по ID. */
 export async function activateTrialById(
   token: string,
   trialId: string,
@@ -368,20 +339,14 @@ export async function activateTrialById(
   subscriptionId: string;
   trialId: string;
   durationDays: number;
-  // для кнопки «🌐 Локации» на экране активации.
   tariffId: string;
   tariffHasLocations: boolean;
-  /** T-unify (12.05.2026) — URL подписки для кнопки «📲 Инструкции по установке». */
   subscriptionUrl?: string | null;
 }> {
   return fetchJson(`/api/client/trials/${encodeURIComponent(trialId)}/activate`, { token, method: "POST" });
 }
 
-/**
- * Перевыпуск subscription URL.
- * Под капотом — Remnawave POST /api/users/{uuid}/actions/revoke (новый shortUuid).
- * type: "root" → id == clientId; type: "secondary" → id == secondarySubscription.id.
- */
+/** Перевыпуск subscription URL. */
 export async function reissueSubscription(
   token: string,
   type: "root" | "secondary",
@@ -395,18 +360,13 @@ export async function getClientDevices(token: string): Promise<{ total: number; 
   return fetchJson("/api/client/devices", { token });
 }
 
-/**
- * все устройства всех подписок клиента (root + secondary),
- * с пометкой откуда. Используется в меню «📱 Мои Устройства» — показывает
- * единый список с подписью «Подписка #N — тариф».
- */
+/** все устройства всех подписок клиента */
 export async function getAllDevices(token: string): Promise<{
   total: number;
   items: {
     hwid: string;
     platform?: string;
     deviceModel?: string;
-    /** приложение (Hiddify / v2rayN / Streisand …). */
     appName?: string;
     createdAt?: string;
     subscriptionType: "root" | "secondary";
@@ -418,10 +378,7 @@ export async function getAllDevices(token: string): Promise<{
   return fetchJson("/api/client/devices/all", { token });
 }
 
-/** Удалить устройство по HWID.
- *  добавили опциональные subscriptionType / subscriptionId —
- *  чтобы устройство удалялось именно из той подписки откуда оно показалось в UI (раньше
- *  endpoint удалял только из root, и для secondary получали «HWID device not found»). */
+/** Удалить устройство по HWID */
 export async function postClientDeviceDelete(
   token: string,
   hwid: string,
@@ -456,21 +413,20 @@ export async function getPublicSingboxTariffs(): Promise<{
   return fetchJson("/api/public/singbox-tariffs");
 }
 
-/** Активные Sing-box слоты клиента (с subscriptionLink) */
+/** Активные Sing-box слоты клиента */
 export async function getSingboxSlots(token: string): Promise<{
   slots: { id: string; subscriptionLink: string; expiresAt: string; protocol: string }[];
 }> {
   return fetchJson("/api/client/singbox-slots", { token });
 }
 
-/** Публичный список тарифов по категориям (emoji из админки по коду ordinary/premium) */
+/** Публичный список тарифов по категориям с кэшированием */
 export async function getPublicTariffs(): Promise<{
   items: {
     id: string;
     name: string;
     emojiKey: string | null;
     emoji: string;
-    /** «одна подписка на категорию» — покупка конвертирует/продлевает существующую. */
     singleSubscriptionMode?: boolean;
     tariffs: {
       id: string;
@@ -486,10 +442,39 @@ export async function getPublicTariffs(): Promise<{
     }[];
   }[];
 }> {
-  return fetchJson("/api/public/tariffs");
+  const now = Date.now();
+  if (cachedTariffs && now - tariffsCacheTime < CACHE_TTL) {
+    return cachedTariffs;
+  }
+
+  const res = await fetchJson<{
+    items: {
+      id: string;
+      name: string;
+      emojiKey: string | null;
+      emoji: string;
+      singleSubscriptionMode?: boolean;
+      tariffs: {
+        id: string;
+        name: string;
+        description?: string | null;
+        durationDays: number;
+        trafficLimitBytes?: number | null;
+        trafficResetMode?: string;
+        deviceLimit?: number | null;
+        price: number;
+        currency: string;
+        priceOptions: { id: string; durationDays: number; price: number; sortOrder: number }[];
+      }[];
+    }[];
+  }>("/api/public/tariffs");
+
+  cachedTariffs = res;
+  tariffsCacheTime = now;
+  return res;
 }
 
-/** Создать платёж Platega (возвращает paymentUrl). Для опции — extraOption. Для прокси — proxyTariffId. */
+/** Создать платёж Platega */
 export async function createPlategaPayment(
   token: string,
   body: {
@@ -504,20 +489,16 @@ export async function createPlategaPayment(
     singboxTariffId?: string;
     promoCode?: string;
     extraOption?: { kind: "traffic" | "devices" | "servers"; productId: string; targetSubscriptionId?: string };
-    /** купить тариф как ДОП. подписку — backend пометит Payment.metadata. */
     asAdditional?: boolean;
-    /** продление существующей secondary (вместо создания новой) */
     extendsSecondarySubId?: string;
-    /** удалить доп. устройства после активации подписки в бэке */
     removeExtrasOnActivate?: boolean;
-    /** заменить конкретный триал при покупке (если триалов несколько) */
     replaceTrialSubId?: string;
   }
 ): Promise<{ paymentUrl: string; orderId: string; paymentId: string }> {
   return fetchJson("/api/client/payments/platega", { method: "POST", body, token });
 }
 
-/** Создать платёж ЮMoney (оплата картой). Для тарифа — tariffId, для прокси — proxyTariffId, для опции — extraOption. */
+/** Создать платёж ЮMoney */
 export async function createYoomoneyPayment(
   token: string,
   body: { amount?: number; paymentType: "PC" | "AC"; tariffId?: string; tariffPriceOptionId?: string; deviceCount?: number; proxyTariffId?: string; singboxTariffId?: string; promoCode?: string; extraOption?: { kind: "traffic" | "devices" | "servers"; productId: string; targetSubscriptionId?: string }; asAdditional?: boolean; extendsSecondarySubId?: string; asGift?: boolean; removeExtrasOnActivate?: boolean; replaceTrialSubId?: string }
@@ -525,9 +506,7 @@ export async function createYoomoneyPayment(
   return fetchJson("/api/client/yoomoney/create-form-payment", { method: "POST", body, token });
 }
 
-/** Создать платёж ЮKassa (карта, СБП). Только RUB. Для тарифа — tariffId, для прокси — proxyTariffId, для опции — extraOption.
- *  19.05.2026 — receiptEmail: 54-ФЗ. Если передан валидный email — ЮКасса пришлёт чек на эту почту,
- *  и email сохраняется в client.email для будущих покупок. Если пусто/невалидно — placeholder (без чека юзеру). */
+/** Создать платёж ЮKassa */
 export async function createYookassaPayment(
   token: string,
   body: { amount?: number; currency?: string; tariffId?: string; tariffPriceOptionId?: string; deviceCount?: number; proxyTariffId?: string; singboxTariffId?: string; promoCode?: string; extraOption?: { kind: "traffic" | "devices" | "servers"; productId: string; targetSubscriptionId?: string }; asAdditional?: boolean; extendsSecondarySubId?: string; asGift?: boolean; removeExtrasOnActivate?: boolean; replaceTrialSubId?: string; receiptEmail?: string }
@@ -535,7 +514,7 @@ export async function createYookassaPayment(
   return fetchJson("/api/client/yookassa/create-payment", { method: "POST", body, token });
 }
 
-/** Crypto Pay (Crypto Bot) — создать инвойс, вернуть ссылку на оплату */
+/** Crypto Pay (Crypto Bot) */
 export async function createCryptopayPayment(
   token: string,
   body: { amount?: number; currency?: string; tariffId?: string; tariffPriceOptionId?: string; deviceCount?: number; proxyTariffId?: string; singboxTariffId?: string; promoCode?: string; extraOption?: { kind: "traffic" | "devices" | "servers"; productId: string; targetSubscriptionId?: string }; asAdditional?: boolean; extendsSecondarySubId?: string; asGift?: boolean; removeExtrasOnActivate?: boolean; replaceTrialSubId?: string }
@@ -544,7 +523,7 @@ export async function createCryptopayPayment(
   return { paymentId: res.paymentId, payUrl: res.payUrl };
 }
 
-/** Heleket — создать инвойс на крипту, вернуть ссылку на оплату */
+/** Heleket */
 export async function createHeleketPayment(
   token: string,
   body: { amount?: number; currency?: string; tariffId?: string; tariffPriceOptionId?: string; deviceCount?: number; proxyTariffId?: string; singboxTariffId?: string; promoCode?: string; extraOption?: { kind: "traffic" | "devices" | "servers"; productId: string }; asAdditional?: boolean; extendsSecondarySubId?: string; asGift?: boolean; removeExtrasOnActivate?: boolean; replaceTrialSubId?: string }
@@ -552,7 +531,7 @@ export async function createHeleketPayment(
   return fetchJson("/api/client/heleket/create-payment", { method: "POST", body, token });
 }
 
-/** RollyPay — создать платёж (СБП/карта/крипта), вернуть ссылку на оплату */
+/** RollyPay */
 export async function createRollypayPayment(
   token: string,
   body: { amount?: number; currency?: string; tariffId?: string; tariffPriceOptionId?: string; deviceCount?: number; proxyTariffId?: string; singboxTariffId?: string; promoCode?: string; extraOption?: { kind: "traffic" | "devices" | "servers"; productId: string }; asAdditional?: boolean; extendsSecondarySubId?: string; asGift?: boolean; removeExtrasOnActivate?: boolean; replaceTrialSubId?: string }
@@ -560,7 +539,7 @@ export async function createRollypayPayment(
   return fetchJson("/api/client/rollypay/create-payment", { method: "POST", body, token });
 }
 
-/** LAVA Business — создать счёт (RUB: СБП / Карты / СберPay) */
+/** LAVA Business */
 export async function createLavaPayment(
   token: string,
   body: { amount?: number; currency?: string; tariffId?: string; tariffPriceOptionId?: string; deviceCount?: number; proxyTariffId?: string; singboxTariffId?: string; promoCode?: string; extraOption?: { kind: "traffic" | "devices" | "servers"; productId: string }; asAdditional?: boolean; extendsSecondarySubId?: string; asGift?: boolean; removeExtrasOnActivate?: boolean; replaceTrialSubId?: string }
@@ -568,12 +547,12 @@ export async function createLavaPayment(
   return fetchJson("/api/client/lava/create-payment", { method: "POST", body, token });
 }
 
-/** Помечает что онбординг (приветствие в боте) завершён — `client.onboardingCompleted=true` */
+/** Помечает что онбординг завершён */
 export async function completeOnboarding(token: string): Promise<{ message: string }> {
   return fetchJson("/api/client/complete-onboarding", { method: "POST", token });
 }
 
-/** Lava.top — создать invoice через product/offer модель (RUB/USD/EUR) */
+/** Lava.top */
 export async function createLavatopPayment(
   token: string,
   body: { amount?: number; currency?: string; tariffId?: string; tariffPriceOptionId?: string; deviceCount?: number; proxyTariffId?: string; singboxTariffId?: string; promoCode?: string; email?: string; offerId?: string; extraOption?: { kind: "traffic" | "devices" | "servers"; productId: string }; asAdditional?: boolean; extendsSecondarySubId?: string; asGift?: boolean; removeExtrasOnActivate?: boolean; replaceTrialSubId?: string }
@@ -581,7 +560,7 @@ export async function createLavatopPayment(
   return fetchJson("/api/client/lavatop/create-payment", { method: "POST", body, token });
 }
 
-/** Обновить профиль (язык, валюта) */
+/** Обновить профиль */
 export async function updateProfile(
   token: string,
   body: { preferredLang?: string; preferredCurrency?: string }
@@ -602,14 +581,12 @@ export async function activateTrial(token: string): Promise<{ message: string }>
   return fetchJson("/api/client/trial", { method: "POST", body: {}, token });
 }
 
-/** Превью конвертации (режим «одна подписка из категории»):
- * узнаём до оплаты, обновит ли покупка существующую подписку. */
+/** Превью конвертации */
 export async function tariffConversionPreview(
   token: string,
   params: { tariffId: string; priceOptionId?: string }
 ): Promise<{
   willConvert: boolean;
-  /** extend — тот же тариф (продление, дни складываются); convert — смена тарифа. */
   mode?: "extend" | "convert" | "replace";
   othersToRemove?: number;
   subscription?: { id: string; index: number; tariffName: string | null; expireAt: string | null; isTrial: boolean };
@@ -617,7 +594,6 @@ export async function tariffConversionPreview(
   convertedDays?: number;
   purchasedDays?: number;
   totalDays?: number;
-  /** расклад по доп. устройствам (сохранить/убрать). */
   extras?: {
     extraDevices: number;
     extraDevicesMonthlyPrice: number;
@@ -631,7 +607,7 @@ export async function tariffConversionPreview(
   return fetchJson(`/api/client/tariff-conversion-preview?${q.toString()}`, { token });
 }
 
-/** Оплата тарифа или прокси-тарифа балансом */
+/** Оплата тарифа балансом */
 export async function payByBalance(
   token: string,
   opts: { tariffId?: string; tariffPriceOptionId?: string; deviceCount?: number; proxyTariffId?: string; singboxTariffId?: string; promoCode?: string; extendsSecondarySubId?: string; asAdditional?: boolean; removeExtrasOnActivate?: boolean; replaceTrialSubId?: string }
@@ -639,8 +615,7 @@ export async function payByBalance(
   return fetchJson("/api/client/payments/balance", { method: "POST", body: opts, token });
 }
 
-/** Оплата опции (доп. трафик/устройства/сервер) с баланса.
- * targetSubscriptionId — к какой подписке применить опцию (для secondary). */
+/** Оплата опции с баланса */
 export async function payOptionByBalance(
   token: string,
   args: { kind: "traffic" | "devices" | "servers"; productId: string; targetSubscriptionId?: string }
@@ -653,12 +628,12 @@ export async function payOptionByBalance(
   });
 }
 
-/** Активировать промо-ссылку (PromoGroup) */
+/** Активировать промо-ссылку */
 export async function activatePromo(token: string, code: string): Promise<{ message: string }> {
   return fetchJson("/api/client/promo/activate", { method: "POST", body: { code }, token });
 }
 
-/** Проверить промокод (PromoCode — скидка / бесплатные дни) */
+/** Проверить промокод */
 export async function checkPromoCode(token: string, code: string): Promise<{ type: string; discountPercent?: number | null; discountFixed?: number | null; durationDays?: number | null; name: string }> {
   return fetchJson("/api/client/promo-code/check", { method: "POST", body: { code }, token });
 }
@@ -668,7 +643,7 @@ export async function activatePromoCode(token: string, code: string): Promise<{ 
   return fetchJson("/api/client/promo-code/activate", { method: "POST", body: { code }, token });
 }
 
-// ——— Bot Admin API (X-Telegram-Bot-Token + telegramId в query/body) ———
+// - Bot Admin API -
 
 const BOT_ADMIN_BASE = "/api/bot-admin";
 
@@ -1023,7 +998,7 @@ export async function postBotAdminClientRemnaSquadRemove(telegramId: number, cli
   return data as { ok: boolean; activeInternalSquads: string[] };
 }
 
-// ——— Gift / Secondary Subscriptions API ———
+// - Gift / Secondary Subscriptions API -
 
 /** Купить дополнительную подписку (оплата балансом) */
 export async function buyGiftSubscription(
@@ -1049,7 +1024,6 @@ export async function createGiftCode(
   code: string;
   expiresAt: string;
   tariffName: string | null;
-  /** T-unify (12.05.2026) — для отображения формата подарка. */
   durationDays: number | null;
   trafficLimitBytes: number | null;
 }> {
@@ -1067,7 +1041,6 @@ export async function redeemGiftCode(
   giftMessage: string | null;
   creatorTelegramId: string | null;
   tariffName: string | null;
-  /** T-unify (12.05.2026) — для текста получателю. */
   durationDays: number | null;
   trafficLimitBytes: number | null;
   subscriptionUrl: string | null;
@@ -1085,11 +1058,7 @@ export async function cancelGiftCode(
   return fetchJson("/api/client/gift/cancel/" + encodeURIComponent(codeOrId), { method: "DELETE", token });
 }
 
-/**
- * получить активный подарочный код для подписки.
- * Используется когда юзер вернулся в «Мои подарки» к подписке с GIFT_RESERVED статусом —
- * чтобы снова показать share-UI для уже созданного кода.
- */
+/** получить активный подарочный код для подписки */
 export async function getActiveGiftCodeForSubscription(
   token: string,
   secondarySubId: string,
@@ -1104,7 +1073,7 @@ export async function getGiftCodes(
   return fetchJson("/api/client/gift/codes", { token });
 }
 
-/** Активировать подписку на себя (снять GIFT_RESERVED) */
+/** Активировать подписку на себя */
 export async function activateGiftForSelf(
   token: string,
   subscriptionId: string
@@ -1128,50 +1097,28 @@ export async function getGiftSubscriptionUrl(
   return fetchJson("/api/client/gift/subscription-url/" + encodeURIComponent(subscriptionId), { token });
 }
 
-// ——— My subscriptions (root + secondary) ———
+// - My subscriptions (root + secondary) -
 
-/**
- * Унифицированный список подписок клиента: root (Client.remnawaveUuid) +
- * secondary (купленные доп. + полученные в подарок). Эндпоинт
- * `/api/client/subscription/all` уже возвращает оба типа в одном массиве —
- * бот использует это в меню «📋 Мои подписки» вместо двух отдельных запросов.
- */
 export type SubscriptionListItem = {
   type: "root" | "secondary";
-  /** Для root — clientId, для secondary — subscriptionId */
   id: string;
   subscriptionIndex: number | null;
-  /** Сырой Remnawave user (для извлечения subscriptionUrl/expireAt) */
   subscription: unknown;
   tariffDisplayName: string;
   remnawaveUuid: string | null;
-  /** id текущего тарифа подписки — для кнопки «Продлить» (быстрая оплата
-   *  того же тарифа без выбора). null если тариф удалён или не определён. */
   tariffId: string | null;
-  /** T15.4 (11.05.2026): id триала, если подписка была создана через активацию пробного.
-   *  Бот рисует пометку «🎁 Пробная» и кнопку «🔄 Конвертировать в платную». null = обычная sub. */
   trialId: string | null;
-  /** включено ли индивидуальное автосписание для этой подписки. */
   autoRenewEnabled?: boolean;
-  /** эмодзи-префикс из админки (Tariff.menuEmoji) для главного меню бота.
-   *  Если null — бот применяет fallback по типу подписки (root → 🌐, secondary → 🔒). */
   tariffMenuEmoji?: string | null;
-  /** кол-во докупленных доп. устройств. */
   extraDevices?: number;
-  /** цена за все доп. устройства на 30 дней. */
   extraDevicesMonthlyPrice?: number;
-  /** для триальных — тарифы, в которые можно конвертировать
-   *  (переход на их сквады). Пусто — только тариф триала. */
   convertTariffIds?: string[];
-  /** имя триала (показывается вместо тарифа). */
   trialName?: string | null;
-  /** false → у триала нет кнопок продления/конвертации вовсе. */
   trialConvertEnabled?: boolean;
-  /** конвертация триала разрешена в любой тариф. */
   trialConvertAllTariffs?: boolean;
 };
 
-/** Убрать ВСЕ доп. устройства с подписки (extraDevices=0, hwid kick в Remna). */
+/** Убрать ВСЕ доп. устройства с подписки */
 export async function removeExtraDevices(
   token: string,
   subType: "root" | "secondary",
@@ -1182,16 +1129,14 @@ export async function removeExtraDevices(
     token,
   });
 }
+
 export async function getAllSubscriptions(
   token: string
 ): Promise<{ items: SubscriptionListItem[] }> {
   return fetchJson("/api/client/subscription/all", { token });
 }
 
-/**
- * pre-check кулдауна продления для конкретной подписки.
- * Бот зовёт перед открытием экрана продления — если blocked, сразу показывает сообщение.
- */
+/** pre-check кулдауна продления */
 export async function checkSubscriptionCooldown(
   token: string,
   subscriptionId: string,
@@ -1199,16 +1144,10 @@ export async function checkSubscriptionCooldown(
   return fetchJson(`/api/client/subscription/${encodeURIComponent(subscriptionId)}/cooldown`, { token });
 }
 
-/**
- * batch-проверка для списка подписок (renew_pick экран).
- * Возвращает массив с blocked-флагами для отрисовки 🚫 на заблокированных подписках.
- */
+/** batch-проверка для списка подписок */
 export async function checkSubscriptionsCooldownBatch(
   token: string,
   ids: string[],
 ): Promise<{ items: Array<{ subscriptionId: string; blocked: boolean; daysLeft?: number; message?: string; tariffName?: string; cooldownDays?: number }> }> {
   return fetchJson("/api/client/subscriptions/cooldown-check", { token, method: "POST", body: { ids } });
 }
-
-// (v5.0.0) Удалены fetchInternalBotsList / reportBotMeUsername — клоны бота больше
-// не поддерживаются, бот один, его токен живёт в process.env.BOT_TOKEN.

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -2485,7 +2485,7 @@ composer.on("callback_query:data", async (ctx) => {
   const data = ctx.callbackQuery.data;
   const userId = ctx.from?.id;
   if (!userId) return;
-  await ctx.answerCallbackQuery().catch(() => {});
+  void ctx.answerCallbackQuery().catch(() => {});
 
   // ─── 54-ФЗ-чек: prompt «нужен ли чек» перед ЮКасса-платежом ───
   // Каждый pay_*_yookassa-handler сохраняет builder+finalize в yk-receipt store и показывает


### PR DESCRIPTION
- Add fatal Remnawave error checks in auto-renew
- Cache getPublicConfig and getPublicTariffs responses
- Add throttling and deduplication for secondary renewals